### PR TITLE
[DONT MERGE] POC to demo lockup

### DIFF
--- a/head_test.go
+++ b/head_test.go
@@ -1,11 +1,16 @@
 package tsdb
 
 import (
+	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"os"
+	"strconv"
 	"testing"
+	"time"
 	"unsafe"
 
+	"github.com/go-kit/kit/log"
 	"github.com/pkg/errors"
 	"github.com/prometheus/tsdb/labels"
 
@@ -71,4 +76,47 @@ func readPrometheusLabels(fn string, n int) ([]labels.Labels, error) {
 		return mets, errors.Errorf("requested %d metrics but found %d", n, i)
 	}
 	return mets, nil
+}
+
+func TestDeadlock(t *testing.T) {
+
+	dir, err := ioutil.TempDir("", "test_persistence_e2e")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	lbls, err := readPrometheusLabels("testdata/20k.series", 1)
+	require.NoError(t, err)
+
+	l := log.NewLogfmtLogger(os.Stdout)
+	ts := time.Now().UnixNano() / 1000000
+
+	hb, err := createHeadBlock(dir, 0, l, ts, ts+50*1000)
+	require.NoError(t, err)
+
+	for i := 0; i < 10; i++ {
+		ts := time.Now().UnixNano() / 1000000
+		for j := 0; j < 10; j++ {
+			app := hb.Appender()
+			go ingestScrapes(t, lbls, strconv.Itoa(j), ts, app)
+		}
+		time.Sleep(1 * time.Second)
+	}
+
+	fmt.Println(hb.Meta().Stats, hb.Busy())
+}
+
+func ingestScrapes(
+	t *testing.T,
+	l []labels.Labels,
+	instance string,
+	ts int64,
+	app Appender,
+) {
+	for _, lset := range l {
+		lset = append(lset, labels.Label{Name: "instance", Value: instance})
+		_, err := app.Add(lset, ts, rand.Float64())
+		require.NoError(t, err)
+	}
+	require.NoError(t, app.Commit())
+	return
 }


### PR DESCRIPTION
So somewhere `Commit` on headBlock is locking up. This is minimal test to reproduce the issue.

```
➜  tsdb git:(head-lock-proof) go test -run Dead -v -timeout 30s .
=== RUN   TestDeadlock
panic: test timed out after 30s

goroutine 98 [running]:
testing.startAlarm.func1()
	/usr/local/go/src/testing/testing.go:1023 +0xf9
created by time.goFunc
	/usr/local/go/src/time/sleep.go:170 +0x44

goroutine 1 [chan receive]:
testing.(*T).Run(0xc420069450, 0x794314, 0xc, 0x7a5938, 0xc42004fd20)
	/usr/local/go/src/testing/testing.go:698 +0x2f4
testing.runTests.func1(0xc420069450)
	/usr/local/go/src/testing/testing.go:882 +0x67
testing.tRunner(0xc420069450, 0xc42004fde0)
	/usr/local/go/src/testing/testing.go:657 +0x96
testing.runTests(0xc42010c880, 0x928e00, 0xe, 0xe, 0x0)
	/usr/local/go/src/testing/testing.go:888 +0x2c1
testing.(*M).Run(0xc42004ff20, 0xc42004ff20)
	/usr/local/go/src/testing/testing.go:822 +0xfc
main.main()
	github.com/prometheus/tsdb/_test/_testmain.go:72 +0xf7

goroutine 17 [syscall, locked to thread]:
runtime.goexit()
	/usr/local/go/src/runtime/asm_amd64.s:2197 +0x1

goroutine 8 [semacquire]:
sync.runtime_Semacquire(0xc4200aa00c)
	/usr/local/go/src/runtime/sema.go:47 +0x34
sync.(*RWMutex).RLock(0xc4200aa000)
	/usr/local/go/src/sync/rwmutex.go:43 +0x49
github.com/prometheus/tsdb.(*headBlock).Appender(0xc4200aa000, 0x110811f2, 0x92c780)
	/home/goutham/gocode/src/github.com/prometheus/tsdb/head.go:237 +0x44
github.com/prometheus/tsdb.TestDeadlock(0xc420069520)
	/home/goutham/gocode/src/github.com/prometheus/tsdb/head_test.go:99 +0x356
testing.tRunner(0xc420069520, 0x7a5938)
	/usr/local/go/src/testing/testing.go:657 +0x96
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:697 +0x2ca

goroutine 14 [select]:
github.com/prometheus/tsdb.(*WAL).run(0xc420070100, 0x12a05f200)
	/home/goutham/gocode/src/github.com/prometheus/tsdb/wal.go:255 +0x352
created by github.com/prometheus/tsdb.OpenWAL
	/home/goutham/gocode/src/github.com/prometheus/tsdb/wal.go:102 +0x2cb

goroutine 84 [semacquire]:
sync.runtime_SemacquireMutex(0xc4200aa004)
	/usr/local/go/src/runtime/sema.go:62 +0x34
sync.(*Mutex).Lock(0xc4200aa000)
	/usr/local/go/src/sync/mutex.go:87 +0x9d
sync.(*RWMutex).Lock(0xc4200aa000)
	/usr/local/go/src/sync/rwmutex.go:86 +0x2d
github.com/prometheus/tsdb.(*headAppender).createSeries(0xc4221e6140)
	/home/goutham/gocode/src/github.com/prometheus/tsdb/head.go:368 +0xe5
github.com/prometheus/tsdb.(*headAppender).Commit(0xc4221e6140, 0x0, 0x0)
	/home/goutham/gocode/src/github.com/prometheus/tsdb/head.go:396 +0xda
github.com/prometheus/tsdb.ingestScrapes(0xc420069520, 0xc42000c2c0, 0x1, 0x1, 0xc420258002, 0x1, 0x15b3e5f3f85, 0x9002a0, 0xc4221e6140)
	/home/goutham/gocode/src/github.com/prometheus/tsdb/head_test.go:120 +0x256
created by github.com/prometheus/tsdb.TestDeadlock
	/home/goutham/gocode/src/github.com/prometheus/tsdb/head_test.go:100 +0x3fc

goroutine 85 [semacquire]:
sync.runtime_SemacquireMutex(0xc4200aa004)
	/usr/local/go/src/runtime/sema.go:62 +0x34
sync.(*Mutex).Lock(0xc4200aa000)
	/usr/local/go/src/sync/mutex.go:87 +0x9d
sync.(*RWMutex).Lock(0xc4200aa000)
	/usr/local/go/src/sync/rwmutex.go:86 +0x2d
github.com/prometheus/tsdb.(*headAppender).createSeries(0xc4221e6190)
	/home/goutham/gocode/src/github.com/prometheus/tsdb/head.go:368 +0xe5
github.com/prometheus/tsdb.(*headAppender).Commit(0xc4221e6190, 0x0, 0x0)
	/home/goutham/gocode/src/github.com/prometheus/tsdb/head.go:396 +0xda
github.com/prometheus/tsdb.ingestScrapes(0xc420069520, 0xc42000c2c0, 0x1, 0x1, 0xc420258003, 0x1, 0x15b3e5f3f85, 0x9002a0, 0xc4221e6190)
	/home/goutham/gocode/src/github.com/prometheus/tsdb/head_test.go:120 +0x256
created by github.com/prometheus/tsdb.TestDeadlock
	/home/goutham/gocode/src/github.com/prometheus/tsdb/head_test.go:100 +0x3fc

goroutine 90 [semacquire]:
sync.runtime_Semacquire(0xc4200aa008)
	/usr/local/go/src/runtime/sema.go:47 +0x34
sync.(*RWMutex).Lock(0xc4200aa000)
	/usr/local/go/src/sync/rwmutex.go:91 +0x6e
github.com/prometheus/tsdb.(*headAppender).createSeries(0xc4221e6320)
	/home/goutham/gocode/src/github.com/prometheus/tsdb/head.go:368 +0xe5
github.com/prometheus/tsdb.(*headAppender).Commit(0xc4221e6320, 0x0, 0x0)
	/home/goutham/gocode/src/github.com/prometheus/tsdb/head.go:396 +0xda
github.com/prometheus/tsdb.ingestScrapes(0xc420069520, 0xc42000c2c0, 0x1, 0x1, 0xc420258008, 0x1, 0x15b3e5f3f85, 0x9002a0, 0xc4221e6320)
	/home/goutham/gocode/src/github.com/prometheus/tsdb/head_test.go:120 +0x256
created by github.com/prometheus/tsdb.TestDeadlock
	/home/goutham/gocode/src/github.com/prometheus/tsdb/head_test.go:100 +0x3fc
exit status 2
FAIL	github.com/prometheus/tsdb	30.009s
```