### PR TITLE
Fix Panic When Accessing Uncut memorySeries

### DIFF
--- a/head.go
+++ b/head.go
@@ -565,6 +565,8 @@ func (h *headBlock) create(hash uint64, lset labels.Labels) *memSeries {
 		lset: lset,
 		ref:  uint32(len(h.series)),
 	}
+	// create the initial chunk and appender
+	s.cut()
 
 	// Allocate empty space until we can insert at the given index.
 	h.series = append(h.series, s)
@@ -627,7 +629,7 @@ func (s *memSeries) append(t int64, v float64) bool {
 
 	var c *memChunk
 
-	if s.app == nil || s.head().samples > 2000 {
+	if s.head().samples > 2000 {
 		c = s.cut()
 		c.minTime = t
 	} else {


### PR DESCRIPTION
When calling AddFast, we check the details of the head chunk of the
referred memorySeries. But it could happen that there are no chunks in
the series at all.

Currently, we are deferring chunk creation to when we actually append
samples, but we can be sure that there will be samples if the series is
created. We will be consuming no extra memory by cutting a chunk when we
create the series.

@fabxc This is not seen until now as we are never calling AddFast twice in a 
transaction, but looks like my (broken) tests went this way.

Ref: #28 comment 2

Signed-off-by: Goutham Veeramachaneni <cs14btech11014@iith.ac.in>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prometheus/tsdb/31)
<!-- Reviewable:end -->
