### PR TITLE
When checking for amended points, do it in terms of bits.

### DIFF
--- a/head.go
+++ b/head.go
@@ -357,7 +357,7 @@ func (a *headAppender) AddFast(ref uint64, t int64, v float64) error {
 		if t < c.maxTime {
 			return ErrOutOfOrderSample
 		}
-		if c.maxTime == t && ms.lastValue != v {
+		if c.maxTime == t && math.Float64bits(ms.lastValue) != math.Float64bits(v) {
 			return ErrAmendSample
 		}
 	}


### PR DESCRIPTION
NaN != NaN, so the previous code would incorrectly report
it as changed.

There's also plans to take advantage of the NaN payload,
so look at the entire value.

@fabxc 