### PR TITLE
Simplify Labels.Equals()

### DIFF
--- a/labels/labels.go
+++ b/labels/labels.go
@@ -84,7 +84,7 @@ func (ls Labels) Equals(o Labels) bool {
 		return false
 	}
 	for i, l := range ls {
-		if l.Name != o[i].Name || l.Value != o[i].Value {
+		if o[i] != l {
 			return false
 		}
 	}

--- a/labels/labels_test.go
+++ b/labels/labels_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCompare(t *testing.T) {
+func TestCompareAndEquals(t *testing.T) {
 	cases := []struct {
 		a, b []Label
 		res  int
@@ -88,6 +88,7 @@ func TestCompare(t *testing.T) {
 		a, b := New(c.a...), New(c.b...)
 
 		require.Equal(t, c.res, Compare(a, b))
+		require.Equal(t, c.res == 0, a.Equals(b))
 	}
 }
 


### PR DESCRIPTION
Also extend the Compare() tests to also test Labels.Equals(). In case that's too ugly, let me know, but it seemed like a convenient reuse of already existing test scenarios for a very similar method.