### PR TITLE
Fix handling of duplicate datapoints

### DIFF
--- a/head.go
+++ b/head.go
@@ -357,7 +357,7 @@ func (a *headAppender) AddFast(ref uint64, t int64, v float64) error {
 		if t < c.maxTime {
 			return ErrOutOfOrderSample
 		}
-		if c.maxTime == t && math.Float64bits(ms.lastValue) != math.Float64bits(v) {
+		if c.maxTime == t {
 			return ErrAmendSample
 		}
 	}
@@ -634,8 +634,7 @@ func (s *memSeries) append(t int64, v float64) bool {
 		c.minTime = t
 	} else {
 		c = s.head()
-		// Skip duplicate samples.
-		if c.maxTime == t && s.lastValue != v {
+		if c.maxTime >= t {
 			return false
 		}
 	}

--- a/head_test.go
+++ b/head_test.go
@@ -15,7 +15,6 @@ package tsdb
 
 import (
 	"io/ioutil"
-	"math"
 	"os"
 	"testing"
 	"unsafe"
@@ -87,7 +86,7 @@ func readPrometheusLabels(fn string, n int) ([]labels.Labels, error) {
 	return mets, nil
 }
 
-func TestAmendDatapointCausesError(t *testing.T) {
+func TestDuplicateDatapointCausesAmendError(t *testing.T) {
 	tmpdir, _ := ioutil.TempDir("", "test")
 	defer os.RemoveAll(tmpdir)
 
@@ -97,67 +96,21 @@ func TestAmendDatapointCausesError(t *testing.T) {
 	}
 
 	app := hb.Appender()
-	_, err = app.Add(labels.Labels{}, 0, 0)
-	if err != nil {
-		t.Fatalf("Failed to add sample: %s", err)
-	}
-	if err = app.Commit(); err != nil {
-		t.Fatalf("Unexpected error committing appender: %s", err)
-	}
+	_, err = app.Add(labels.Labels{}, 1, 0)
+	require.NoError(t, err)
+
+	err = app.Commit()
+	require.NoError(t, err)
 
 	app = hb.Appender()
-	_, err = app.Add(labels.Labels{}, 0, 1)
-	if err != ErrAmendSample {
-		t.Fatalf("Expected error amending sample, got: %s", err)
-	}
-}
 
-func TestDuplicateNaNDatapointNoAmendError(t *testing.T) {
-	tmpdir, _ := ioutil.TempDir("", "test")
-	defer os.RemoveAll(tmpdir)
+	_, err = app.Add(labels.Labels{}, 1, 1)
+	require.Equal(t, ErrAmendSample, err)
+	_, err = app.Add(labels.Labels{}, 1, 0)
+	require.Equal(t, ErrAmendSample, err)
+	_, err = app.Add(labels.Labels{}, 2, 0)
+	require.NoError(t, err)
 
-	hb, err := createHeadBlock(tmpdir+"/hb", 0, nil, 0, 1000)
-	if err != nil {
-		t.Fatalf("Error creating head block: %s", err)
-	}
-
-	app := hb.Appender()
-	_, err = app.Add(labels.Labels{}, 0, math.NaN())
-	if err != nil {
-		t.Fatalf("Failed to add sample: %s", err)
-	}
-	if err = app.Commit(); err != nil {
-		t.Fatalf("Unexpected error committing appender: %s", err)
-	}
-
-	app = hb.Appender()
-	_, err = app.Add(labels.Labels{}, 0, math.NaN())
-	if err != nil {
-		t.Fatalf("Unexpected error adding duplicate NaN sample, got: %s", err)
-	}
-}
-
-func TestNonDuplicateNaNDatapointsCausesAmendError(t *testing.T) {
-	tmpdir, _ := ioutil.TempDir("", "test")
-	defer os.RemoveAll(tmpdir)
-
-	hb, err := createHeadBlock(tmpdir+"/hb", 0, nil, 0, 1000)
-	if err != nil {
-		t.Fatalf("Error creating head block: %s", err)
-	}
-
-	app := hb.Appender()
-	_, err = app.Add(labels.Labels{}, 0, math.Float64frombits(0x7ff0000000000001))
-	if err != nil {
-		t.Fatalf("Failed to add sample: %s", err)
-	}
-	if err = app.Commit(); err != nil {
-		t.Fatalf("Unexpected error committing appender: %s", err)
-	}
-
-	app = hb.Appender()
-	_, err = app.Add(labels.Labels{}, 0, math.Float64frombits(0x7ff0000000000002))
-	if err != ErrAmendSample {
-		t.Fatalf("Expected error amending sample, got: %s", err)
-	}
+	err = app.Commit()
+	require.NoError(t, err)
 }


### PR DESCRIPTION
Currently if we allow appending two equal samples (both t, v). This
fixes the behaviour by not allowing two samples with the same ts.

Also we could previously append out of order or equal samples when in
the same transaction. This fixes it.

cc @fabxc @brian-brazil before we forget the discussion in #42

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prometheus/tsdb/72)
<!-- Reviewable:end -->
