### PR TITLE
Fix missing postings in Merge and Intersect

### DIFF
--- a/head.go
+++ b/head.go
@@ -112,7 +112,7 @@ func openHeadBlock(dir string, l log.Logger) (*headBlock, error) {
 	h := &headBlock{
 		dir:      dir,
 		wal:      wal,
-		series:   []*memSeries{},
+		series:   []*memSeries{nil}, // 0 is not a valid posting, filled with nil.
 		hashes:   map[uint64][]*memSeries{},
 		values:   map[string]stringset{},
 		postings: &memPostings{m: make(map[term][]uint32)},

--- a/postings_test.go
+++ b/postings_test.go
@@ -78,23 +78,35 @@ func TestIntersect(t *testing.T) {
 
 func TestMultiIntersect(t *testing.T) {
 	var cases = []struct {
-		a, b, c []uint32
-		res     []uint32
+		p   [][]uint32
+		res []uint32
 	}{
 		{
-			a:   []uint32{1, 2, 3, 4, 5, 6, 1000, 1001},
-			b:   []uint32{2, 4, 5, 6, 7, 8, 999, 1001},
-			c:   []uint32{1, 2, 5, 6, 7, 8, 1001, 1200},
+			p: [][]uint32{
+				{1, 2, 3, 4, 5, 6, 1000, 1001},
+				{2, 4, 5, 6, 7, 8, 999, 1001},
+				{1, 2, 5, 6, 7, 8, 1001, 1200},
+			},
 			res: []uint32{2, 5, 6, 1001},
+		},
+		{
+			p: [][]uint32{
+				{1, 2},
+				{1, 2},
+				{1, 2},
+				{2},
+			},
+			res: []uint32{2},
 		},
 	}
 
 	for _, c := range cases {
-		pa := newListPostings(c.a)
-		pb := newListPostings(c.b)
-		pc := newListPostings(c.c)
+		ps := make([]Postings, 0, len(c.p))
+		for _, postings := range c.p {
+			ps = append(ps, newListPostings(postings))
+		}
 
-		res, err := expandPostings(Intersect(pa, pb, pc))
+		res, err := expandPostings(Intersect(ps...))
 
 		require.NoError(t, err)
 		require.Equal(t, c.res, res)

--- a/postings_test.go
+++ b/postings_test.go
@@ -340,3 +340,18 @@ func TestBigEndian(t *testing.T) {
 		}
 	})
 }
+
+func TestIntersectWithMerge(t *testing.T) {
+	a := newListPostings([]uint32{21, 22, 23, 24, 25, 30})
+
+	b := newMergedPostings(
+		newListPostings([]uint32{10, 20, 30}),
+		newListPostings([]uint32{15, 26, 30}),
+	)
+
+	p := Intersect(a, b)
+	res, err := expandPostings(p)
+
+	require.NoError(t, err)
+	require.Equal(t, []uint32{30}, res)
+}

--- a/postings_test.go
+++ b/postings_test.go
@@ -212,12 +212,12 @@ func TestMergedPostingsSeek(t *testing.T) {
 		res     []uint32
 	}{
 		{
-			a: []uint32{1, 2, 3, 4, 5},
+			a: []uint32{2, 3, 4, 5},
 			b: []uint32{6, 7, 8, 9, 10},
 
-			seek:    0,
+			seek:    1,
 			success: true,
-			res:     []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+			res:     []uint32{2, 3, 4, 5, 6, 7, 8, 9, 10},
 		},
 		{
 			a: []uint32{1, 2, 3, 4, 5},
@@ -252,9 +252,16 @@ func TestMergedPostingsSeek(t *testing.T) {
 		p := newMergedPostings(a, b)
 
 		require.Equal(t, c.success, p.Seek(c.seek))
-		lst, err := expandPostings(p)
-		require.NoError(t, err)
-		require.Equal(t, c.res, lst)
+
+		// After Seek(), At() should be called.
+		if c.success {
+			start := p.At()
+			lst, err := expandPostings(p)
+			require.NoError(t, err)
+
+			lst = append([]uint32{start}, lst...)
+			require.Equal(t, c.res, lst)
+		}
 	}
 
 	return
@@ -305,16 +312,16 @@ func TestBigEndian(t *testing.T) {
 				ls[600] + 1, ls[601], true,
 			},
 			{
-				ls[600] + 1, ls[602], true,
+				ls[600] + 1, ls[601], true,
 			},
 			{
-				ls[600] + 1, ls[603], true,
+				ls[600] + 1, ls[601], true,
 			},
 			{
-				ls[0], ls[604], true,
+				ls[0], ls[601], true,
 			},
 			{
-				ls[600], ls[605], true,
+				ls[600], ls[601], true,
 			},
 			{
 				ls[999], ls[999], true,

--- a/postings_test.go
+++ b/postings_test.go
@@ -89,6 +89,10 @@ func TestMultiIntersect(t *testing.T) {
 			},
 			res: []uint32{2, 5, 6, 1001},
 		},
+		// One of the reproduceable cases for:
+		// https://github.com/prometheus/prometheus/issues/2616
+		// The initialisation of intersectPostings was moving the iterator forward
+		// prematurely making us miss some postings.
 		{
 			p: [][]uint32{
 				{1, 2},
@@ -342,6 +346,8 @@ func TestBigEndian(t *testing.T) {
 }
 
 func TestIntersectWithMerge(t *testing.T) {
+	// One of the reproduceable cases for:
+	// https://github.com/prometheus/prometheus/issues/2616
 	a := newListPostings([]uint32{21, 22, 23, 24, 25, 30})
 
 	b := newMergedPostings(


### PR DESCRIPTION
Before we were moving the postings list everytime we create a new
chained `intersectPostings`. That was causing some postings to be
skipped. This test fails on the older version.

Signed-off-by: Goutham Veeramachaneni <cs14btech11014@iith.ac.in>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prometheus/tsdb/77)
<!-- Reviewable:end -->
