### PR TITLE
Various type improvements

### DIFF
--- a/block.go
+++ b/block.go
@@ -48,8 +48,8 @@ type Block interface {
 	Queryable
 }
 
-// HeadBlock is a regular block that can still be appended to.
-type HeadBlock interface {
+// headBlock is a regular block that can still be appended to.
+type headBlock interface {
 	Block
 	Appendable
 }

--- a/head_test.go
+++ b/head_test.go
@@ -39,7 +39,7 @@ func BenchmarkCreateSeries(b *testing.B) {
 		require.NoError(b, err)
 		defer os.RemoveAll(dir)
 
-		h, err := createHeadBlock(dir, 0, nil, 0, 1)
+		h, err := CreateHeadBlock(dir, 0, nil, 0, 1)
 		require.NoError(b, err)
 
 		b.ReportAllocs()
@@ -93,7 +93,7 @@ func TestAmendDatapointCausesError(t *testing.T) {
 	tmpdir, _ := ioutil.TempDir("", "test")
 	defer os.RemoveAll(tmpdir)
 
-	hb, err := createHeadBlock(tmpdir+"/hb", 0, nil, 0, 1000)
+	hb, err := CreateHeadBlock(tmpdir+"/hb", 0, nil, 0, 1000)
 	require.NoError(t, err, "Error creating head block")
 
 	app := hb.Appender()
@@ -110,7 +110,7 @@ func TestDuplicateNaNDatapointNoAmendError(t *testing.T) {
 	tmpdir, _ := ioutil.TempDir("", "test")
 	defer os.RemoveAll(tmpdir)
 
-	hb, err := createHeadBlock(tmpdir+"/hb", 0, nil, 0, 1000)
+	hb, err := CreateHeadBlock(tmpdir+"/hb", 0, nil, 0, 1000)
 	require.NoError(t, err, "Error creating head block")
 
 	app := hb.Appender()
@@ -127,7 +127,7 @@ func TestNonDuplicateNaNDatapointsCausesAmendError(t *testing.T) {
 	tmpdir, _ := ioutil.TempDir("", "test")
 	defer os.RemoveAll(tmpdir)
 
-	hb, err := createHeadBlock(tmpdir+"/hb", 0, nil, 0, 1000)
+	hb, err := CreateHeadBlock(tmpdir+"/hb", 0, nil, 0, 1000)
 	require.NoError(t, err, "Error creating head block")
 
 	app := hb.Appender()
@@ -144,7 +144,7 @@ func TestSkippingInvalidValuesInSameTxn(t *testing.T) {
 	tmpdir, _ := ioutil.TempDir("", "test")
 	defer os.RemoveAll(tmpdir)
 
-	hb, err := createHeadBlock(tmpdir+"/hb", 0, nil, 0, 1000)
+	hb, err := CreateHeadBlock(tmpdir+"/hb", 0, nil, 0, 1000)
 	require.NoError(t, err)
 
 	// Append AmendedValue.
@@ -246,7 +246,7 @@ func TestHeadBlock_e2e(t *testing.T) {
 	tmpdir, _ := ioutil.TempDir("", "test")
 	defer os.RemoveAll(tmpdir)
 
-	hb, err := createHeadBlock(tmpdir+"/hb", 0, nil, minTime, maxTime)
+	hb, err := CreateHeadBlock(tmpdir+"/hb", 0, nil, minTime, maxTime)
 	require.NoError(t, err)
 	app := hb.Appender()
 

--- a/head_test.go
+++ b/head_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"sort"
 	"testing"
+	"time"
 	"unsafe"
 
 	"github.com/pkg/errors"
@@ -30,6 +31,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// createTestHeadBlock creates a new head block with a SegmentWAL.
+func createTestHeadBlock(t testing.TB, dir string, mint, maxt int64) *HeadBlock {
+	err := TouchHeadBlock(dir, 0, mint, maxt)
+	require.NoError(t, err)
+
+	wal, err := OpenSegmentWAL(dir, nil, 5*time.Second)
+	require.NoError(t, err)
+
+	h, err := OpenHeadBlock(dir, nil, wal)
+	require.NoError(t, err)
+	return h
+}
+
 func BenchmarkCreateSeries(b *testing.B) {
 	lbls, err := readPrometheusLabels("cmd/tsdb/testdata.1m", 1e6)
 	require.NoError(b, err)
@@ -39,8 +53,7 @@ func BenchmarkCreateSeries(b *testing.B) {
 		require.NoError(b, err)
 		defer os.RemoveAll(dir)
 
-		h, err := CreateHeadBlock(dir, 0, nil, 0, 1)
-		require.NoError(b, err)
+		h := createTestHeadBlock(b, dir, 0, 1)
 
 		b.ReportAllocs()
 		b.ResetTimer()
@@ -90,14 +103,13 @@ func readPrometheusLabels(fn string, n int) ([]labels.Labels, error) {
 }
 
 func TestAmendDatapointCausesError(t *testing.T) {
-	tmpdir, _ := ioutil.TempDir("", "test")
-	defer os.RemoveAll(tmpdir)
+	dir, _ := ioutil.TempDir("", "test")
+	defer os.RemoveAll(dir)
 
-	hb, err := CreateHeadBlock(tmpdir+"/hb", 0, nil, 0, 1000)
-	require.NoError(t, err, "Error creating head block")
+	hb := createTestHeadBlock(t, dir, 0, 1000)
 
 	app := hb.Appender()
-	_, err = app.Add(labels.Labels{}, 0, 0)
+	_, err := app.Add(labels.Labels{}, 0, 0)
 	require.NoError(t, err, "Failed to add sample")
 	require.NoError(t, app.Commit(), "Unexpected error committing appender")
 
@@ -107,14 +119,13 @@ func TestAmendDatapointCausesError(t *testing.T) {
 }
 
 func TestDuplicateNaNDatapointNoAmendError(t *testing.T) {
-	tmpdir, _ := ioutil.TempDir("", "test")
-	defer os.RemoveAll(tmpdir)
+	dir, _ := ioutil.TempDir("", "test")
+	defer os.RemoveAll(dir)
 
-	hb, err := CreateHeadBlock(tmpdir+"/hb", 0, nil, 0, 1000)
-	require.NoError(t, err, "Error creating head block")
+	hb := createTestHeadBlock(t, dir, 0, 1000)
 
 	app := hb.Appender()
-	_, err = app.Add(labels.Labels{}, 0, math.NaN())
+	_, err := app.Add(labels.Labels{}, 0, math.NaN())
 	require.NoError(t, err, "Failed to add sample")
 	require.NoError(t, app.Commit(), "Unexpected error committing appender")
 
@@ -124,14 +135,13 @@ func TestDuplicateNaNDatapointNoAmendError(t *testing.T) {
 }
 
 func TestNonDuplicateNaNDatapointsCausesAmendError(t *testing.T) {
-	tmpdir, _ := ioutil.TempDir("", "test")
-	defer os.RemoveAll(tmpdir)
+	dir, _ := ioutil.TempDir("", "test")
+	defer os.RemoveAll(dir)
 
-	hb, err := CreateHeadBlock(tmpdir+"/hb", 0, nil, 0, 1000)
-	require.NoError(t, err, "Error creating head block")
+	hb := createTestHeadBlock(t, dir, 0, 1000)
 
 	app := hb.Appender()
-	_, err = app.Add(labels.Labels{}, 0, math.Float64frombits(0x7ff0000000000001))
+	_, err := app.Add(labels.Labels{}, 0, math.Float64frombits(0x7ff0000000000001))
 	require.NoError(t, err, "Failed to add sample")
 	require.NoError(t, app.Commit(), "Unexpected error committing appender")
 
@@ -141,15 +151,14 @@ func TestNonDuplicateNaNDatapointsCausesAmendError(t *testing.T) {
 }
 
 func TestSkippingInvalidValuesInSameTxn(t *testing.T) {
-	tmpdir, _ := ioutil.TempDir("", "test")
-	defer os.RemoveAll(tmpdir)
+	dir, _ := ioutil.TempDir("", "test")
+	defer os.RemoveAll(dir)
 
-	hb, err := CreateHeadBlock(tmpdir+"/hb", 0, nil, 0, 1000)
-	require.NoError(t, err)
+	hb := createTestHeadBlock(t, dir, 0, 1000)
 
 	// Append AmendedValue.
 	app := hb.Appender()
-	_, err = app.Add(labels.Labels{{"a", "b"}}, 0, 1)
+	_, err := app.Add(labels.Labels{{"a", "b"}}, 0, 1)
 	require.NoError(t, err)
 	_, err = app.Add(labels.Labels{{"a", "b"}}, 0, 2)
 	require.NoError(t, err)
@@ -243,11 +252,10 @@ func TestHeadBlock_e2e(t *testing.T) {
 		seriesMap[labels.New(l...).String()] = []sample{}
 	}
 
-	tmpdir, _ := ioutil.TempDir("", "test")
-	defer os.RemoveAll(tmpdir)
+	dir, _ := ioutil.TempDir("", "test")
+	defer os.RemoveAll(dir)
 
-	hb, err := CreateHeadBlock(tmpdir+"/hb", 0, nil, minTime, maxTime)
-	require.NoError(t, err)
+	hb := createTestHeadBlock(t, dir, minTime, maxTime)
 	app := hb.Appender()
 
 	for _, l := range lbls {


### PR DESCRIPTION
The `HeadBlock` interface was only used internally, which is not good in general. Interfaces should serve the purpose of composability. The implementation is now public and the interface unexported for internal usage.

For the same reason, the WAL is an interface now and the implementation was renamed to `SegmentWAL`. Head block tests still use the SegmentWAL, but could now inject WALs simulating write failures as well.

The `refdSample` is now `RefSample` as it shows up in an exported method. The WAL interface overall still has some warts, but this should be a fair bit better already.

@Gouthamve 