### PR TITLE
Snapshot support

### DIFF
--- a/block.go
+++ b/block.go
@@ -1,4 +1,5 @@
 // Copyright 2017 The Prometheus Authors
+
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -52,13 +53,13 @@ type DiskBlock interface {
 type Block interface {
 	DiskBlock
 	Queryable
+	Snapshottable
 }
 
 // headBlock is a regular block that can still be appended to.
 type headBlock interface {
 	Block
 	Appendable
-	Snapshottable
 }
 
 // Snapshottable defines an entity that can be backedup online.
@@ -276,6 +277,42 @@ Outer:
 
 	pb.meta.Stats.NumTombstones = uint64(len(pb.tombstones))
 	return writeMetaFile(pb.dir, &pb.meta)
+}
+
+func (pb *persistedBlock) Snapshot(dir string) error {
+	blockDir := filepath.Join(dir, pb.meta.ULID.String())
+	if err := os.MkdirAll(blockDir, 0777); err != nil {
+		return errors.Wrap(err, "create snapshot block dir")
+	}
+
+	chunksDir := chunkDir(blockDir)
+	if err := os.MkdirAll(chunksDir, 0777); err != nil {
+		return errors.Wrap(err, "create snapshot chunk dir")
+	}
+
+	// Hardlink meta, index and tombstones
+	filenames := []string{metaFilename, indexFilename, tombstoneFilename}
+	for _, fname := range filenames {
+		if err := os.Link(filepath.Join(pb.dir, fname), filepath.Join(blockDir, fname)); err != nil {
+			return errors.Wrapf(err, "create snapshot %s", fname)
+		}
+	}
+
+	// Hardlink the chunks
+	curChunkDir := chunkDir(pb.dir)
+	files, err := ioutil.ReadDir(curChunkDir)
+	if err != nil {
+		return errors.Wrap(err, "ReadDir the current chunk dir")
+	}
+
+	for _, f := range files {
+		err := os.Link(filepath.Join(curChunkDir, f.Name()), filepath.Join(chunksDir, f.Name()))
+		if err != nil {
+			return errors.Wrap(err, "hardlink a chunk")
+		}
+	}
+
+	return nil
 }
 
 func chunkDir(dir string) string { return filepath.Join(dir, "chunks") }

--- a/block.go
+++ b/block.go
@@ -58,6 +58,12 @@ type Block interface {
 type headBlock interface {
 	Block
 	Appendable
+	Snapshottable
+}
+
+// Snapshottable defines an entity that can be backedup online.
+type Snapshottable interface {
+	Snapshot(dir string) error
 }
 
 // Appendable defines an entity to which data can be appended.

--- a/block.go
+++ b/block.go
@@ -291,8 +291,11 @@ func (pb *persistedBlock) Snapshot(dir string) error {
 	}
 
 	// Hardlink meta, index and tombstones
-	filenames := []string{metaFilename, indexFilename, tombstoneFilename}
-	for _, fname := range filenames {
+	for _, fname := range []string{
+		metaFilename,
+		indexFilename,
+		tombstoneFilename,
+	} {
 		if err := os.Link(filepath.Join(pb.dir, fname), filepath.Join(blockDir, fname)); err != nil {
 			return errors.Wrapf(err, "create snapshot %s", fname)
 		}

--- a/compact.go
+++ b/compact.go
@@ -246,7 +246,7 @@ func (c *compactor) write(uid ulid.ULID, blocks ...Block) (err error) {
 		return errors.Wrap(err, "open index writer")
 	}
 
-	meta, err := c.populate(blocks, indexw, chunkw)
+	meta, err := populateBlock(blocks, indexw, chunkw)
 	if err != nil {
 		return errors.Wrap(err, "write compaction")
 	}
@@ -289,9 +289,9 @@ func (c *compactor) write(uid ulid.ULID, blocks ...Block) (err error) {
 	return nil
 }
 
-// populate fills the index and chunk writers with new data gathered as the union
+// populateBlock fills the index and chunk writers with new data gathered as the union
 // of the provided blocks. It returns meta information for the new block.
-func (c *compactor) populate(blocks []Block, indexw IndexWriter, chunkw ChunkWriter) (*BlockMeta, error) {
+func populateBlock(blocks []Block, indexw IndexWriter, chunkw ChunkWriter) (*BlockMeta, error) {
 	var set compactionSet
 
 	for i, b := range blocks {

--- a/db.go
+++ b/db.go
@@ -531,25 +531,21 @@ func (db *DB) Close() error {
 }
 
 // DisableCompactions disables compactions.
-func (db *DB) DisableCompactions() error {
+func (db *DB) DisableCompactions() {
 	if db.compacting {
 		db.cmtx.Lock()
 		db.compacting = false
 		db.logger.Log("msg", "compactions disabled")
 	}
-
-	return nil
 }
 
 // EnableCompactions enables compactions.
-func (db *DB) EnableCompactions() error {
+func (db *DB) EnableCompactions() {
 	if !db.compacting {
 		db.cmtx.Unlock()
 		db.compacting = true
 		db.logger.Log("msg", "compactions enabled")
 	}
-
-	return nil
 }
 
 // Snapshot writes the current data to the directory.

--- a/head.go
+++ b/head.go
@@ -262,6 +262,71 @@ Outer:
 	return nil
 }
 
+// Snapshot persists the current state of the headblock to the given directory.
+func (h *HeadBlock) Snapshot(snapshotDir string) error {
+	// Needed to stop any appenders.
+	h.mtx.Lock()
+	defer h.mtx.Unlock()
+
+	if h.meta.Stats.NumSeries == 0 {
+		return nil
+	}
+
+	entropy := rand.New(rand.NewSource(time.Now().UnixNano()))
+	uid := ulid.MustNew(ulid.Now(), entropy)
+
+	dir := filepath.Join(snapshotDir, uid.String())
+	tmp := dir + ".tmp"
+
+	if err := os.RemoveAll(tmp); err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(tmp, 0777); err != nil {
+		return err
+	}
+
+	// Populate chunk and index files into temporary directory with
+	// data of all blocks.
+	chunkw, err := newChunkWriter(chunkDir(tmp))
+	if err != nil {
+		return errors.Wrap(err, "open chunk writer")
+	}
+	indexw, err := newIndexWriter(tmp)
+	if err != nil {
+		return errors.Wrap(err, "open index writer")
+	}
+
+	meta, err := populateBlock([]Block{h}, indexw, chunkw)
+	if err != nil {
+		return errors.Wrap(err, "write snapshot")
+	}
+	meta.ULID = uid
+
+	if err = writeMetaFile(tmp, meta); err != nil {
+		return errors.Wrap(err, "write merged meta")
+	}
+
+	if err = chunkw.Close(); err != nil {
+		return errors.Wrap(err, "close chunk writer")
+	}
+	if err = indexw.Close(); err != nil {
+		return errors.Wrap(err, "close index writer")
+	}
+
+	// Create an empty tombstones file.
+	if err := writeTombstoneFile(tmp, newEmptyTombstoneReader()); err != nil {
+		return errors.Wrap(err, "write new tombstones file")
+	}
+
+	// Block successfully written, make visible
+	if err := renameFile(tmp, dir); err != nil {
+		return errors.Wrap(err, "rename block dir")
+	}
+
+	return nil
+}
+
 // Dir returns the directory of the block.
 func (h *HeadBlock) Dir() string { return h.dir }
 

--- a/head.go
+++ b/head.go
@@ -263,11 +263,10 @@ Outer:
 }
 
 // Snapshot persists the current state of the headblock to the given directory.
+// TODO(gouthamve): Snapshot must be called when there are no active appenders.
+// This has been ensured by acquiring a Lock on DB.mtx, but this limitation should
+// be removed in the future.
 func (h *HeadBlock) Snapshot(snapshotDir string) error {
-	// Needed to stop any appenders.
-	h.mtx.Lock()
-	defer h.mtx.Unlock()
-
 	if h.meta.Stats.NumSeries == 0 {
 		return nil
 	}

--- a/index.go
+++ b/index.go
@@ -39,6 +39,8 @@ const (
 	indexFormatV1 = 1
 )
 
+const indexFilename = "index"
+
 const compactionPageBytes = minSectorSize * 64
 
 type indexWriterSeries struct {
@@ -138,7 +140,7 @@ func newIndexWriter(dir string) (*indexWriter, error) {
 	if err != nil {
 		return nil, err
 	}
-	f, err := os.OpenFile(filepath.Join(dir, "index"), os.O_CREATE|os.O_WRONLY, 0666)
+	f, err := os.OpenFile(filepath.Join(dir, indexFilename), os.O_CREATE|os.O_WRONLY, 0666)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
For snapshotting HeadBlock:
Step 1: Lock HeadBlock against new appenders and let existing appenders finish.
Step 2: Write out the HeadBlock to a folder as a persisted block.

Now as we are blocking writes during snapshots, I am not sure how it will behave under heavy ingestion. WDYT @fabxc?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prometheus/tsdb/88)
<!-- Reviewable:end -->
