### PR TITLE
Improve heuristic to spread chunks across block

### DIFF
--- a/cmd/tsdb/main.go
+++ b/cmd/tsdb/main.go
@@ -113,7 +113,7 @@ func (b *writeBenchmark) run(cmd *cobra.Command, args []string) {
 	st, err := tsdb.Open(dir, nil, nil, &tsdb.Options{
 		WALFlushInterval:  200 * time.Millisecond,
 		RetentionDuration: 2 * 24 * 60 * 60 * 1000, // 1 days in milliseconds
-		MinBlockDuration:  3 * 60 * 60 * 1000,      // 2 hours in milliseconds
+		MinBlockDuration:  3 * 60 * 60 * 1000,      // 3 hours in milliseconds
 		MaxBlockDuration:  27 * 60 * 60 * 1000,     // 1 days in milliseconds
 	})
 	if err != nil {
@@ -157,6 +157,8 @@ func (b *writeBenchmark) run(cmd *cobra.Command, args []string) {
 	})
 }
 
+const timeDelta = 30000
+
 func (b *writeBenchmark) ingestScrapes(lbls []labels.Labels, scrapeCount int) (uint64, error) {
 	var mu sync.Mutex
 	var total uint64
@@ -174,7 +176,7 @@ func (b *writeBenchmark) ingestScrapes(lbls []labels.Labels, scrapeCount int) (u
 
 			wg.Add(1)
 			go func() {
-				n, err := b.ingestScrapesShard(batch, 100, int64(30000*i))
+				n, err := b.ingestScrapesShard(batch, 100, int64(timeDelta*i))
 				if err != nil {
 					// exitWithError(err)
 					fmt.Println(" err", err)
@@ -212,7 +214,7 @@ func (b *writeBenchmark) ingestScrapesShard(metrics []labels.Labels, scrapeCount
 
 	for i := 0; i < scrapeCount; i++ {
 		app := b.storage.Appender()
-		ts += int64(30000)
+		ts += timeDelta
 
 		for _, s := range scrape {
 			s.value += 1000

--- a/compact.go
+++ b/compact.go
@@ -314,6 +314,8 @@ func populateBlock(blocks []Block, indexw IndexWriter, chunkw ChunkWriter) (*Blo
 	var metas []BlockMeta
 
 	for i, b := range blocks {
+		metas = append(metas, b.Meta())
+
 		all, err := b.Index().Postings("", "")
 		if err != nil {
 			return nil, err
@@ -328,7 +330,6 @@ func populateBlock(blocks []Block, indexw IndexWriter, chunkw ChunkWriter) (*Blo
 		if err != nil {
 			return nil, err
 		}
-		metas = append(metas, b.Meta())
 	}
 
 	// We fully rebuild the postings list index from merged series.

--- a/head_test.go
+++ b/head_test.go
@@ -731,3 +731,45 @@ Outer:
 
 	return ds
 }
+
+func TestComputeChunkEndTime(t *testing.T) {
+	cases := []struct {
+		start, cur, max int64
+		res             int64
+	}{
+		{
+			start: 0,
+			cur:   250,
+			max:   1000,
+			res:   1000,
+		},
+		{
+			start: 100,
+			cur:   200,
+			max:   1000,
+			res:   550,
+		},
+		// Case where we fit floored 0 chunks. Must catch division by 0
+		// and default to maximum time.
+		{
+			start: 0,
+			cur:   500,
+			max:   1000,
+			res:   1000,
+		},
+		// Catch divison by zero for cur == start. Strictly not a possible case.
+		{
+			start: 100,
+			cur:   100,
+			max:   1000,
+			res:   104,
+		},
+	}
+
+	for _, c := range cases {
+		got := computeChunkEndTime(c.start, c.cur, c.max)
+		if got != c.res {
+			t.Errorf("expected %d for (start: %d, cur: %d, max: %d), got %d", c.res, c.start, c.cur, c.max, got)
+		}
+	}
+}


### PR DESCRIPTION
This yields ideally balanced chunks within a block, given that the incoming data has regular timestamps. Any more sophisticated handling seems pointless given that the most frequent cause for unbalanced chunks with this change will be series churn, which we cannot predict.

@Gouthamve 