### PR TITLE
Fix directory file descriptor leak.

### DIFF
--- a/compact.go
+++ b/compact.go
@@ -300,6 +300,8 @@ func (c *compactor) write(uid ulid.ULID, blocks ...Block) (err error) {
 	if err != nil {
 		return errors.Wrap(err, "sync block dir")
 	}
+	defer df.Close()
+
 	if err := fileutil.Fsync(df); err != nil {
 		return errors.Wrap(err, "sync block dir")
 	}
@@ -583,6 +585,8 @@ func renameFile(from, to string) error {
 	if err != nil {
 		return err
 	}
+	defer pdir.Close()
+
 	if err = fileutil.Fsync(pdir); err != nil {
 		return err
 	}

--- a/db.go
+++ b/db.go
@@ -386,6 +386,8 @@ func retentionCutoff(dir string, mint int64) (bool, error) {
 	if err != nil {
 		return false, errors.Wrapf(err, "open directory")
 	}
+	defer df.Close()
+
 	dirs, err := blockDirs(dir)
 	if err != nil {
 		return false, errors.Wrapf(err, "list block dirs %s", dir)


### PR DESCRIPTION
@Gouthamve 

I was under the impression leaking FDs would be released once the objects get cleaned up. Maybe my case was just too fast for that to actually happen. Regardless, this should be fixed obviously.