### PR TITLE
Compact head block early

### DIFF
--- a/block.go
+++ b/block.go
@@ -60,6 +60,11 @@ type Block interface {
 type headBlock interface {
 	Block
 	Appendable
+
+	// ActiveWriters returns the number of currently active appenders.
+	ActiveWriters() int
+	// HighTimestamp returns the highest currently inserted timestamp.
+	HighTimestamp() int64
 }
 
 // Snapshottable defines an entity that can be backedup online.
@@ -71,9 +76,6 @@ type Snapshottable interface {
 type Appendable interface {
 	// Appender returns a new Appender against an underlying store.
 	Appender() Appender
-
-	// Busy returns whether there are any currently active appenders.
-	Busy() bool
 }
 
 // Queryable defines an entity which provides a Querier.

--- a/db.go
+++ b/db.go
@@ -80,6 +80,7 @@ type Appender interface {
 	// Returned reference numbers are ephemeral and may be rejected in calls
 	// to AddFast() at any point. Adding the sample via Add() returns a new
 	// reference number.
+	// If the reference is the empty string it must not be used for caching.
 	Add(l labels.Labels, t int64, v float64) (string, error)
 
 	// Add adds a sample pair for the referenced series. It is generally faster
@@ -616,6 +617,9 @@ func (a *dbAppender) Add(lset labels.Labels, t int64, v float64) (string, error)
 	}
 	a.samples++
 
+	if ref == "" {
+		return "", nil
+	}
 	return string(append(h.meta.ULID[:], ref...)), nil
 }
 

--- a/head.go
+++ b/head.go
@@ -57,6 +57,7 @@ type HeadBlock struct {
 	wal WAL
 
 	activeWriters uint64
+	highTimestamp int64
 	closed        bool
 
 	// descs holds all chunk descs for the head block. Each chunk implicitly
@@ -389,9 +390,14 @@ func (h *HeadBlock) Appender() Appender {
 	return &headAppender{HeadBlock: h, samples: getHeadAppendBuffer()}
 }
 
-// Busy returns true if the block has open write transactions.
-func (h *HeadBlock) Busy() bool {
-	return atomic.LoadUint64(&h.activeWriters) > 0
+// ActiveWriters returns true if the block has open write transactions.
+func (h *HeadBlock) ActiveWriters() int {
+	return int(atomic.LoadUint64(&h.activeWriters))
+}
+
+// HighTimestamp returns the highest inserted sample timestamp.
+func (h *HeadBlock) HighTimestamp() int64 {
+	return atomic.LoadInt64(&h.highTimestamp)
 }
 
 var headPool = sync.Pool{}
@@ -415,7 +421,8 @@ type headAppender struct {
 	newLabels []labels.Labels
 	newHashes map[uint64]uint64
 
-	samples []RefSample
+	samples       []RefSample
+	highTimestamp int64
 }
 
 type hashedLabels struct {
@@ -513,6 +520,10 @@ func (a *headAppender) AddFast(ref string, t int64, v float64) error {
 		}
 	}
 
+	if t > a.highTimestamp {
+		a.highTimestamp = t
+	}
+
 	a.samples = append(a.samples, RefSample{
 		Ref: refn,
 		T:   t,
@@ -592,6 +603,16 @@ func (a *headAppender) Commit() error {
 
 	atomic.AddUint64(&a.meta.Stats.NumSamples, total)
 	atomic.AddUint64(&a.meta.Stats.NumSeries, uint64(len(a.newSeries)))
+
+	for {
+		ht := a.HeadBlock.HighTimestamp()
+		if a.highTimestamp <= ht {
+			break
+		}
+		if atomic.CompareAndSwapInt64(&a.HeadBlock.highTimestamp, ht, a.highTimestamp) {
+			break
+		}
+	}
 
 	return nil
 }

--- a/head.go
+++ b/head.go
@@ -450,7 +450,7 @@ func (a *headAppender) Add(lset labels.Labels, t int64, v float64) (string, erro
 		// XXX(fabxc): there's no fast path for multiple samples for the same new series
 		// in the same transaction. We always return the invalid empty ref. It's has not
 		// been a relevant use case so far and is not worth the trouble.
-		return nullRef, a.AddFast(string(refb), t, v)
+		return "", a.AddFast(string(refb), t, v)
 	}
 
 	// The series is completely new.
@@ -471,10 +471,8 @@ func (a *headAppender) Add(lset labels.Labels, t int64, v float64) (string, erro
 	a.newHashes[hash] = ref
 	binary.BigEndian.PutUint64(refb, ref)
 
-	return nullRef, a.AddFast(string(refb), t, v)
+	return "", a.AddFast(string(refb), t, v)
 }
-
-var nullRef = string([]byte{0, 0, 0, 0, 0, 0, 0, 0})
 
 func (a *headAppender) AddFast(ref string, t int64, v float64) error {
 	if len(ref) != 8 {

--- a/querier.go
+++ b/querier.go
@@ -38,7 +38,7 @@ type Querier interface {
 	Close() error
 }
 
-// Series represents a single time series.
+// Series exposes a single time series.
 type Series interface {
 	// Labels returns the complete set of labels identifying the series.
 	Labels() labels.Labels


### PR DESCRIPTION
Let older head blocks be compacted once the newest once has samples at
50% of its total range. This allows the memory of the compacted blocks
to be released and garbage collected before a new head block gets
created. Thereby the number of head blocks is 1 or 2 instead of 2 or 3
and memory spikes are reduced.

This saves us 10-20% in spike usage.