### PR TITLE
Persist the right MaxTime when snapshotting

### DIFF
--- a/db.go
+++ b/db.go
@@ -710,7 +710,7 @@ func (db *DB) ensureHead(t int64) error {
 	}
 	// Create another block of buffer in front if the DB is initialized or retrieving
 	// new data after a long gap.
-	// This ensures we always have a full block width if append window.
+	// This ensures we always have a full block width of append window.
 	if addBuffer {
 		if _, err := db.createHeadBlock(mint-int64(db.opts.MinBlockDuration), mint); err != nil {
 			return err

--- a/head.go
+++ b/head.go
@@ -302,6 +302,7 @@ func (h *HeadBlock) Snapshot(snapshotDir string) error {
 		return errors.Wrap(err, "write snapshot")
 	}
 	meta.ULID = uid
+	meta.MaxTime = h.highTimestamp
 
 	if err = writeMetaFile(tmp, meta); err != nil {
 		return errors.Wrap(err, "write merged meta")


### PR DESCRIPTION
This is because we cut a new block from where the snapshotted block ends
if we restore from backups and highTimestamp would be where we should be
 starting from.