### PR TITLE
Fix compactions

### DIFF
--- a/cmd/tsdb/main.go
+++ b/cmd/tsdb/main.go
@@ -113,7 +113,7 @@ func (b *writeBenchmark) run(cmd *cobra.Command, args []string) {
 	st, err := tsdb.Open(dir, nil, nil, &tsdb.Options{
 		WALFlushInterval:  200 * time.Millisecond,
 		RetentionDuration: 15 * 24 * 60 * 60 * 1000, // 15 days in milliseconds
-		BlockRanges:       tsdb.ExponentialBlockRanges(3*60*60*1000, 3, 5),
+		BlockRanges:       tsdb.ExponentialBlockRanges(2*60*60*1000, 5, 3),
 	})
 	if err != nil {
 		exitWithError(err)

--- a/compact_test.go
+++ b/compact_test.go
@@ -49,6 +49,22 @@ func TestCompactionSelect(t *testing.T) {
 			planned: nil,
 		},
 		{
+			// We should wait for a third block of size 20 to appear before compacting
+			// the existing ones.
+			blocks: []dirMetaSimple{
+				{
+					dir: "1",
+					tr:  []int64{0, 20},
+				},
+				{
+					dir: "2",
+					tr:  []int64{20, 40},
+				},
+			},
+			planned: nil,
+		},
+		{
+			// Block to fill the entire parent range appeared – should be compacted.
 			blocks: []dirMetaSimple{
 				{
 					dir: "1",
@@ -64,6 +80,25 @@ func TestCompactionSelect(t *testing.T) {
 				},
 			},
 			planned: [][]string{{"1", "2", "3"}},
+		},
+		{
+			// Block for the next parent range appeared. Nothing will happen in the first one
+			// anymore and we should compact it.
+			blocks: []dirMetaSimple{
+				{
+					dir: "1",
+					tr:  []int64{0, 20},
+				},
+				{
+					dir: "2",
+					tr:  []int64{20, 40},
+				},
+				{
+					dir: "3",
+					tr:  []int64{60, 80},
+				},
+			},
+			planned: [][]string{{"1", "2"}},
 		},
 		{
 			blocks: []dirMetaSimple{
@@ -93,16 +128,8 @@ func TestCompactionSelect(t *testing.T) {
 		{
 			blocks: []dirMetaSimple{
 				{
-					dir: "1",
-					tr:  []int64{0, 20},
-				},
-				{
 					dir: "2",
 					tr:  []int64{20, 40},
-				},
-				{
-					dir: "3",
-					tr:  []int64{40, 60},
 				},
 				{
 					dir: "4",
@@ -121,24 +148,28 @@ func TestCompactionSelect(t *testing.T) {
 					tr:  []int64{1200, 1440},
 				},
 			},
-			planned: [][]string{{"6", "7"}},
+			planned: [][]string{{"2", "4", "5"}},
 		},
 		{
 			blocks: []dirMetaSimple{
 				{
 					dir: "1",
-					tr:  []int64{0, 20},
+					tr:  []int64{0, 60},
 				},
 				{
-					dir: "2",
+					dir: "4",
 					tr:  []int64{60, 80},
 				},
 				{
-					dir: "3",
+					dir: "5",
 					tr:  []int64{80, 100},
 				},
+				{
+					dir: "6",
+					tr:  []int64{100, 120},
+				},
 			},
-			planned: [][]string{{"2", "3"}},
+			planned: [][]string{{"4", "5", "6"}},
 		},
 	}
 

--- a/db.go
+++ b/db.go
@@ -360,8 +360,11 @@ func (db *DB) completedHeads() (r []headBlock) {
 	// Add the 2nd last head if the last head is more than 50% filled.
 	// Compacting it early allows us to free its memory before allocating
 	// more for the next block and thus reduces spikes.
-	if h2 := db.heads[len(db.heads)-2]; headFullness(h2) >= 0.5 && h2.ActiveWriters() == 0 {
-		r = append(r, h2)
+	h0 := db.heads[len(db.heads)-1]
+	h1 := db.heads[len(db.heads)-2]
+
+	if headFullness(h0) >= 0.5 && h1.ActiveWriters() == 0 {
+		r = append(r, h1)
 	}
 	return r
 }


### PR DESCRIPTION
@Gouthamve I switched to starting with the smallest range. This should guarantee us that the first pick is the one we want instead of correcting afterwards.
Switched from recursive to iterative approach to – recursion is pretty but a for loop seemed easier to grasp in this particular case.

Currently have a prombench running to verify that everything works.