### PR TITLE
Avoid chunk allocations and refactor compactions

### DIFF
--- a/block.go
+++ b/block.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
+	"github.com/prometheus/tsdb/chunks"
 	"github.com/prometheus/tsdb/labels"
 )
 
@@ -181,13 +182,13 @@ type persistedBlock struct {
 	tombstones tombstoneReader
 }
 
-func newPersistedBlock(dir string) (*persistedBlock, error) {
+func newPersistedBlock(dir string, pool chunks.Pool) (*persistedBlock, error) {
 	meta, err := readMetaFile(dir)
 	if err != nil {
 		return nil, err
 	}
 
-	cr, err := newChunkReader(chunkDir(dir))
+	cr, err := newChunkReader(chunkDir(dir), pool)
 	if err != nil {
 		return nil, err
 	}

--- a/block.go
+++ b/block.go
@@ -252,7 +252,7 @@ func (pb *persistedBlock) Delete(mint, maxt int64, ms ...labels.Matcher) error {
 	stones := map[uint32]intervals{}
 
 	var lset labels.Labels
-	var chks []*ChunkMeta
+	var chks []ChunkMeta
 
 Outer:
 	for p.Next() {

--- a/block.go
+++ b/block.go
@@ -113,7 +113,7 @@ type BlockStats struct {
 type BlockMetaCompaction struct {
 	// Maximum number of compaction cycles any source block has
 	// gone through.
-	Generation int `json:"generation"`
+	Level int `json:"level"`
 	// ULIDs of all source head blocks that went into the block.
 	Sources []ulid.ULID `json:"sources,omitempty"`
 }

--- a/chunks.go
+++ b/chunks.go
@@ -238,20 +238,22 @@ func (w *chunkWriter) WriteChunks(chks ...ChunkMeta) error {
 		}
 	}
 
-	b := make([]byte, binary.MaxVarintLen32)
-	seq := uint64(w.seq()) << 32
-
+	var (
+		b   = [binary.MaxVarintLen32]byte{}
+		seq = uint64(w.seq()) << 32
+	)
 	for i := range chks {
 		chk := &chks[i]
 
 		chk.Ref = seq | uint64(w.n)
 
-		n := binary.PutUvarint(b, uint64(len(chk.Chunk.Bytes())))
+		n := binary.PutUvarint(b[:], uint64(len(chk.Chunk.Bytes())))
 
 		if err := w.write(b[:n]); err != nil {
 			return err
 		}
-		if err := w.write([]byte{byte(chk.Chunk.Encoding())}); err != nil {
+		b[0] = byte(chk.Chunk.Encoding())
+		if err := w.write(b[:1]); err != nil {
 			return err
 		}
 		if err := w.write(chk.Chunk.Bytes()); err != nil {
@@ -262,7 +264,7 @@ func (w *chunkWriter) WriteChunks(chks ...ChunkMeta) error {
 		if err := chk.writeHash(w.crc32); err != nil {
 			return err
 		}
-		if err := w.write(w.crc32.Sum(nil)); err != nil {
+		if err := w.write(w.crc32.Sum(b[:0])); err != nil {
 			return err
 		}
 	}
@@ -295,15 +297,20 @@ type chunkReader struct {
 
 	// Closers for resources behind the byte slices.
 	cs []io.Closer
+
+	pool chunks.Pool
 }
 
 // newChunkReader returns a new chunkReader based on mmaped files found in dir.
-func newChunkReader(dir string) (*chunkReader, error) {
+func newChunkReader(dir string, pool chunks.Pool) (*chunkReader, error) {
 	files, err := sequenceFiles(dir, "")
 	if err != nil {
 		return nil, err
 	}
-	var cr chunkReader
+	if pool == nil {
+		pool = chunks.NewPool()
+	}
+	cr := chunkReader{pool: pool}
 
 	for _, fn := range files {
 		f, err := openMmapFile(fn)
@@ -350,11 +357,6 @@ func (s *chunkReader) Chunk(ref uint64) (chunks.Chunk, error) {
 		return nil, fmt.Errorf("reading chunk length failed")
 	}
 	b = b[n:]
-	enc := chunks.Encoding(b[0])
 
-	c, err := chunks.FromData(enc, b[1:1+l])
-	if err != nil {
-		return nil, err
-	}
-	return c, nil
+	return s.pool.Get(chunks.Encoding(b[0]), b[1:1+l])
 }

--- a/chunks/chunk.go
+++ b/chunks/chunk.go
@@ -104,6 +104,9 @@ func (p *pool) Put(c Chunk) error {
 	switch c.Encoding() {
 	case EncXOR:
 		xc, ok := c.(*XORChunk)
+		// This may happen often with wrapped chunks. Nothing we can really do about
+		// it but returning an error would cause a lot of allocations again. Thus,
+		// we just skip it.
 		if !ok {
 			return nil
 		}

--- a/chunks/chunk.go
+++ b/chunks/chunk.go
@@ -13,7 +13,12 @@
 
 package chunks
 
-import "fmt"
+import (
+	"fmt"
+	"sync"
+
+	"github.com/pkg/errors"
+)
 
 // Encoding is the identifier for a chunk encoding.
 type Encoding uint8
@@ -62,4 +67,51 @@ type Iterator interface {
 	At() (int64, float64)
 	Err() error
 	Next() bool
+}
+
+type Pool interface {
+	Put(Chunk) error
+	Get(e Encoding, b []byte) (Chunk, error)
+}
+
+// Pool is a memory pool of chunk objects.
+type pool struct {
+	xor sync.Pool
+}
+
+func NewPool() Pool {
+	return &pool{
+		xor: sync.Pool{
+			New: func() interface{} {
+				return &XORChunk{b: &bstream{}}
+			},
+		},
+	}
+}
+
+func (p *pool) Get(e Encoding, b []byte) (Chunk, error) {
+	switch e {
+	case EncXOR:
+		c := p.xor.Get().(*XORChunk)
+		c.b.stream = b
+		c.b.count = 0
+		return c, nil
+	}
+	return nil, errors.Errorf("invalid encoding %q", e)
+}
+
+func (p *pool) Put(c Chunk) error {
+	switch c.Encoding() {
+	case EncXOR:
+		xc, ok := c.(*XORChunk)
+		if !ok {
+			return nil
+		}
+		xc.b.stream = nil
+		xc.b.count = 0
+		p.xor.Put(c)
+	default:
+		return errors.Errorf("invalid encoding %q", c.Encoding())
+	}
+	return nil
 }

--- a/compact_test.go
+++ b/compact_test.go
@@ -19,8 +19,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCompactionSelect(t *testing.T) {
-	opts := &compactorOptions{
+func TestLeveledCompactor_Select(t *testing.T) {
+	opts := &LeveledCompactorOptions{
 		blockRanges: []int64{
 			20,
 			60,
@@ -173,7 +173,7 @@ func TestCompactionSelect(t *testing.T) {
 		},
 	}
 
-	c := &compactor{
+	c := &LeveledCompactor{
 		opts: opts,
 	}
 	sliceDirs := func(dms []dirMeta) [][]string {

--- a/db.go
+++ b/db.go
@@ -224,7 +224,7 @@ func Open(dir string, l log.Logger, r prometheus.Registerer, opts *Options) (db 
 		db.lockf = &lockf
 	}
 
-	copts := &compactorOptions{
+	copts := &LeveledCompactorOptions{
 		blockRanges: opts.BlockRanges,
 		chunkPool:   db.chunkPool,
 	}
@@ -242,7 +242,7 @@ func Open(dir string, l log.Logger, r prometheus.Registerer, opts *Options) (db 
 		copts.blockRanges = copts.blockRanges[:len(copts.blockRanges)-1]
 	}
 
-	db.compactor = NewCompactor(dir, r, l, copts)
+	db.compactor = NewLeveledCompactor(r, l, copts)
 
 	if err := db.reloadBlocks(); err != nil {
 		return nil, err
@@ -390,20 +390,24 @@ func (db *DB) compact() (changes bool, err error) {
 		default:
 		}
 
-		if err = db.compactor.Write(h); err != nil {
+		if err = db.compactor.Write(db.dir, h); err != nil {
 			return changes, errors.Wrap(err, "persist head block")
 		}
 		changes = true
+
+		if err := os.RemoveAll(h.Dir()); err != nil {
+			return changes, errors.Wrap(err, "delete compacted head block")
+		}
 		runtime.GC()
 	}
 
 	// Check for compactions of multiple blocks.
 	for {
-		plans, err := db.compactor.Plan()
+		plan, err := db.compactor.Plan(db.dir)
 		if err != nil {
 			return changes, errors.Wrap(err, "plan compaction")
 		}
-		if len(plans) == 0 {
+		if len(plan) == 0 {
 			break
 		}
 
@@ -413,17 +417,17 @@ func (db *DB) compact() (changes bool, err error) {
 		default:
 		}
 
-		// We just execute compactions sequentially to not cause too extreme
-		// CPU and memory spikes.
-		// TODO(fabxc): return more descriptive plans in the future that allow
-		// estimation of resource usage and conditional parallelization?
-		for _, p := range plans {
-			if err := db.compactor.Compact(p...); err != nil {
-				return changes, errors.Wrapf(err, "compact %s", p)
-			}
-			changes = true
-			runtime.GC()
+		if err := db.compactor.Compact(db.dir, plan...); err != nil {
+			return changes, errors.Wrapf(err, "compact %s", plan)
 		}
+		changes = true
+
+		for _, pd := range plan {
+			if err := os.RemoveAll(pd); err != nil {
+				return changes, errors.Wrap(err, "delete compacted block")
+			}
+		}
+		runtime.GC()
 	}
 
 	return changes, nil
@@ -509,7 +513,7 @@ func (db *DB) reloadBlocks() (err error) {
 
 		b, ok := db.getBlock(meta.ULID)
 		if !ok {
-			if meta.Compaction.Generation == 0 {
+			if meta.Compaction.Level == 0 {
 				b, err = db.openHeadBlock(dir)
 			} else {
 				b, err = newPersistedBlock(dir, db.chunkPool)
@@ -538,7 +542,7 @@ func (db *DB) reloadBlocks() (err error) {
 	db.heads = nil
 
 	for _, b := range blocks {
-		if b.Meta().Compaction.Generation == 0 {
+		if b.Meta().Compaction.Level == 0 {
 			db.heads = append(db.heads, b.(*HeadBlock))
 		}
 	}
@@ -607,6 +611,9 @@ func (db *DB) EnableCompactions() {
 
 // Snapshot writes the current data to the directory.
 func (db *DB) Snapshot(dir string) error {
+	if dir == db.dir {
+		return errors.Errorf("cannot snapshot into base directory")
+	}
 	db.cmtx.Lock()
 	defer db.cmtx.Unlock()
 
@@ -873,7 +880,7 @@ func (db *DB) openHeadBlock(dir string) (*HeadBlock, error) {
 		return nil, errors.Wrap(err, "open WAL %s")
 	}
 
-	h, err := OpenHeadBlock(dir, log.With(db.logger, "block", dir), wal)
+	h, err := OpenHeadBlock(dir, log.With(db.logger, "block", dir), wal, db.compactor)
 	if err != nil {
 		return nil, errors.Wrapf(err, "open head block %s", dir)
 	}

--- a/head.go
+++ b/head.go
@@ -702,7 +702,7 @@ func (h *headIndexReader) SortedPostings(p Postings) Postings {
 }
 
 // Series returns the series for the given reference.
-func (h *headIndexReader) Series(ref uint32, lbls *labels.Labels, chks *[]*ChunkMeta) error {
+func (h *headIndexReader) Series(ref uint32, lbls *labels.Labels, chks *[]ChunkMeta) error {
 	h.mtx.RLock()
 	defer h.mtx.RUnlock()
 
@@ -722,7 +722,7 @@ func (h *headIndexReader) Series(ref uint32, lbls *labels.Labels, chks *[]*Chunk
 	*chks = (*chks)[:0]
 
 	for i, c := range s.chunks {
-		*chks = append(*chks, &ChunkMeta{
+		*chks = append(*chks, ChunkMeta{
 			MinTime: c.minTime,
 			MaxTime: c.maxTime,
 			Ref:     (uint64(ref) << 32) | uint64(i),

--- a/head.go
+++ b/head.go
@@ -270,62 +270,62 @@ Outer:
 // This has been ensured by acquiring a Lock on DB.mtx, but this limitation should
 // be removed in the future.
 func (h *HeadBlock) Snapshot(snapshotDir string) error {
-	if h.meta.Stats.NumSeries == 0 {
-		return nil
-	}
+	// if h.meta.Stats.NumSeries == 0 {
+	// 	return nil
+	// }
 
-	entropy := rand.New(rand.NewSource(time.Now().UnixNano()))
-	uid := ulid.MustNew(ulid.Now(), entropy)
+	// entropy := rand.New(rand.NewSource(time.Now().UnixNano()))
+	// uid := ulid.MustNew(ulid.Now(), entropy)
 
-	dir := filepath.Join(snapshotDir, uid.String())
-	tmp := dir + ".tmp"
+	// dir := filepath.Join(snapshotDir, uid.String())
+	// tmp := dir + ".tmp"
 
-	if err := os.RemoveAll(tmp); err != nil {
-		return err
-	}
+	// if err := os.RemoveAll(tmp); err != nil {
+	// 	return err
+	// }
 
-	if err := os.MkdirAll(tmp, 0777); err != nil {
-		return err
-	}
+	// if err := os.MkdirAll(tmp, 0777); err != nil {
+	// 	return err
+	// }
 
-	// Populate chunk and index files into temporary directory with
-	// data of all blocks.
-	chunkw, err := newChunkWriter(chunkDir(tmp))
-	if err != nil {
-		return errors.Wrap(err, "open chunk writer")
-	}
-	indexw, err := newIndexWriter(tmp)
-	if err != nil {
-		return errors.Wrap(err, "open index writer")
-	}
+	// // Populate chunk and index files into temporary directory with
+	// // data of all blocks.
+	// chunkw, err := newChunkWriter(chunkDir(tmp))
+	// if err != nil {
+	// 	return errors.Wrap(err, "open chunk writer")
+	// }
+	// indexw, err := newIndexWriter(tmp)
+	// if err != nil {
+	// 	return errors.Wrap(err, "open index writer")
+	// }
 
-	meta, err := populateBlock([]Block{h}, indexw, chunkw)
-	if err != nil {
-		return errors.Wrap(err, "write snapshot")
-	}
-	meta.ULID = uid
-	meta.MaxTime = h.highTimestamp
+	// meta, err := h.compactor.populateBlock([]Block{h}, indexw, chunkw, nil)
+	// if err != nil {
+	// 	return errors.Wrap(err, "write snapshot")
+	// }
+	// meta.ULID = uid
+	// meta.MaxTime = h.highTimestamp
 
-	if err = writeMetaFile(tmp, meta); err != nil {
-		return errors.Wrap(err, "write merged meta")
-	}
+	// if err = writeMetaFile(tmp, meta); err != nil {
+	// 	return errors.Wrap(err, "write merged meta")
+	// }
 
-	if err = chunkw.Close(); err != nil {
-		return errors.Wrap(err, "close chunk writer")
-	}
-	if err = indexw.Close(); err != nil {
-		return errors.Wrap(err, "close index writer")
-	}
+	// if err = chunkw.Close(); err != nil {
+	// 	return errors.Wrap(err, "close chunk writer")
+	// }
+	// if err = indexw.Close(); err != nil {
+	// 	return errors.Wrap(err, "close index writer")
+	// }
 
-	// Create an empty tombstones file.
-	if err := writeTombstoneFile(tmp, newEmptyTombstoneReader()); err != nil {
-		return errors.Wrap(err, "write new tombstones file")
-	}
+	// // Create an empty tombstones file.
+	// if err := writeTombstoneFile(tmp, newEmptyTombstoneReader()); err != nil {
+	// 	return errors.Wrap(err, "write new tombstones file")
+	// }
 
-	// Block successfully written, make visible
-	if err := renameFile(tmp, dir); err != nil {
-		return errors.Wrap(err, "rename block dir")
-	}
+	// // Block successfully written, make visible
+	// if err := renameFile(tmp, dir); err != nil {
+	// 	return errors.Wrap(err, "rename block dir")
+	// }
 
 	return nil
 }

--- a/head_test.go
+++ b/head_test.go
@@ -43,7 +43,7 @@ func openTestHeadBlock(t testing.TB, dir string) *HeadBlock {
 	wal, err := OpenSegmentWAL(dir, nil, 5*time.Second)
 	require.NoError(t, err)
 
-	h, err := OpenHeadBlock(dir, nil, wal)
+	h, err := OpenHeadBlock(dir, nil, wal, nil)
 	require.NoError(t, err)
 	return h
 }


### PR DESCRIPTION
@Gouthamve 

depends on #116 
Compaction spikes are gone now. Only thing that's causing relevant allocations is rebuilding of postings lists. That can cause spikes with high series churn but TBD whether they are big enough to require optimizations.

I refactored the compactor along the way.

<img width="1407" alt="screen shot 2017-08-09 at 08 55 37" src="https://user-images.githubusercontent.com/4948210/29114103-786144b0-7cf3-11e7-9234-8f97bf87263b.png">
