### PR TITLE
Add newCRC32 function to simplify hash initialization

### DIFF
--- a/chunks.go
+++ b/chunks.go
@@ -18,7 +18,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"hash"
-	"hash/crc32"
 	"io"
 	"os"
 
@@ -136,7 +135,7 @@ func newChunkWriter(dir string) (*chunkWriter, error) {
 	cw := &chunkWriter{
 		dirFile:     dirFile,
 		n:           0,
-		crc32:       crc32.New(crc32.MakeTable(crc32.Castagnoli)),
+		crc32:       newCRC32(),
 		segmentSize: defaultChunkSegmentSize,
 	}
 	return cw, nil

--- a/index.go
+++ b/index.go
@@ -18,7 +18,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"hash"
-	"hash/crc32"
 	"io"
 	"os"
 	"path/filepath"
@@ -177,7 +176,7 @@ func newIndexWriter(dir string) (*indexWriter, error) {
 		// Caches.
 		symbols:       make(map[string]uint32, 1<<13),
 		seriesOffsets: make(map[uint32]uint64, 1<<16),
-		crc32:         crc32.New(crc32.MakeTable(crc32.Castagnoli)),
+		crc32:         newCRC32(),
 	}
 	if err := iw.writeMeta(); err != nil {
 		return nil, err

--- a/tombstones.go
+++ b/tombstones.go
@@ -16,7 +16,6 @@ package tsdb
 import (
 	"encoding/binary"
 	"fmt"
-	"hash/crc32"
 	"io"
 	"io/ioutil"
 	"os"
@@ -37,7 +36,7 @@ const (
 func writeTombstoneFile(dir string, tr tombstoneReader) error {
 	path := filepath.Join(dir, tombstoneFilename)
 	tmp := path + ".tmp"
-	hash := crc32.New(crc32.MakeTable(crc32.Castagnoli))
+	hash := newCRC32()
 
 	f, err := os.Create(tmp)
 	if err != nil {
@@ -114,7 +113,7 @@ func readTombstones(dir string) (tombstoneReader, error) {
 	}
 
 	// Verify checksum
-	hash := crc32.New(crc32.MakeTable(crc32.Castagnoli))
+	hash := newCRC32()
 	if _, err := hash.Write(d.get()); err != nil {
 		return nil, errors.Wrap(err, "write to hash")
 	}

--- a/wal.go
+++ b/wal.go
@@ -112,6 +112,12 @@ func init() {
 	castagnoliTable = crc32.MakeTable(crc32.Castagnoli)
 }
 
+// newCRC32 initializes a CRC32 hash with a preconfigured polynomial, so the
+// polynomial may be easily changed in one location at a later time, if necessary.
+func newCRC32() hash.Hash32 {
+	return crc32.New(castagnoliTable)
+}
+
 // OpenSegmentWAL opens or creates a write ahead log in the given directory.
 // The WAL must be read completely before new data is written.
 func OpenSegmentWAL(dir string, logger log.Logger, flushInterval time.Duration) (*SegmentWAL, error) {
@@ -133,7 +139,7 @@ func OpenSegmentWAL(dir string, logger log.Logger, flushInterval time.Duration) 
 		donec:         make(chan struct{}),
 		stopc:         make(chan struct{}),
 		segmentSize:   walSegmentSizeBytes,
-		crc32:         crc32.New(castagnoliTable),
+		crc32:         newCRC32(),
 	}
 	if err := w.initSegments(); err != nil {
 		return nil, err
@@ -524,7 +530,7 @@ func newWALReader(w *SegmentWAL, l log.Logger) *walReader {
 		logger: l,
 		wal:    w,
 		buf:    make([]byte, 0, 128*4096),
-		crc32:  crc32.New(crc32.MakeTable(crc32.Castagnoli)),
+		crc32:  newCRC32(),
 	}
 }
 


### PR DESCRIPTION
Tidies things up a bit, and makes it easier to change the polynomial in one place later on, if deemed necessary.