### PR TITLE
WIP: use packages from prometheus/common instead of prometheus/prometheus/pkg

### DIFF
--- a/cmd/tsdb/main.go
+++ b/cmd/tsdb/main.go
@@ -29,8 +29,8 @@ import (
 	"unsafe"
 
 	"github.com/pkg/errors"
-	promlabels "github.com/prometheus/prometheus/pkg/labels"
-	"github.com/prometheus/prometheus/pkg/textparse"
+	promlabels "github.com/prometheus/common/labels"
+	"github.com/prometheus/common/textparse"
 	"github.com/prometheus/tsdb"
 	"github.com/prometheus/tsdb/labels"
 	"github.com/spf13/cobra"

--- a/head_test.go
+++ b/head_test.go
@@ -26,8 +26,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/tsdb/labels"
 
-	promlabels "github.com/prometheus/prometheus/pkg/labels"
-	"github.com/prometheus/prometheus/pkg/textparse"
+	promlabels "github.com/prometheus/common/labels"
+	"github.com/prometheus/common/textparse"
 	"github.com/stretchr/testify/require"
 )
 

--- a/labels/labels_test.go
+++ b/labels/labels_test.go
@@ -23,8 +23,8 @@ import (
 	"unsafe"
 
 	"github.com/pkg/errors"
-	promlabels "github.com/prometheus/prometheus/pkg/labels"
-	"github.com/prometheus/prometheus/pkg/textparse"
+	promlabels "github.com/prometheus/common/labels"
+	"github.com/prometheus/common/textparse"
 	"github.com/stretchr/testify/require"
 )
 


### PR DESCRIPTION
This commit depends on the change https://github.com/prometheus/common/pull/101 which allows developing and using tsdb without needing prometheus dev branch