### PR TITLE
Add list blocks command to CLI

### DIFF
--- a/cmd/tsdb/main.go
+++ b/cmd/tsdb/main.go
@@ -60,7 +60,7 @@ func main() {
 		if err != nil {
 			exitWithError(err)
 		}
-		db.PrintBlocks()
+		printBlocks(db.Blocks())
 	}
 	flag.CommandLine.Set("log.level", "debug")
 }
@@ -330,4 +330,22 @@ func readPrometheusLabels(r io.Reader, n int) ([]labels.Labels, error) {
 func exitWithError(err error) {
 	fmt.Fprintln(os.Stderr, err)
 	os.Exit(1)
+}
+
+func printBlocks(blocks []tsdb.DiskBlock) {
+	tw := tsdb.GetNewTabWriter(os.Stdout)
+	defer tw.Flush()
+
+	fmt.Fprintln(tw, "BLOCK ULID\tMIN TIME\tMAX TIME\tNUM SAMPLES\tNUM CHUNKS\tNUM SERIES")
+	for _, b := range blocks {
+		fmt.Fprintf(tw,
+			"%v\t%v\t%v\t%v\t%v\t%v\n",
+			b.Meta().ULID,
+			b.Meta().MinTime,
+			b.Meta().MaxTime,
+			b.Meta().Stats.NumSamples,
+			b.Meta().Stats.NumChunks,
+			b.Meta().Stats.NumSeries,
+		)
+	}
 }

--- a/cmd/tsdb/main.go
+++ b/cmd/tsdb/main.go
@@ -43,6 +43,8 @@ func main() {
 		benchWriteOutPath    = benchWriteCmd.Flag("out", "set the output path").Default("benchout/").String()
 		benchWriteNumMetrics = benchWriteCmd.Flag("metrics", "number of metrics to read").Default("10000").Int()
 		benchSamplesFile     = benchWriteCmd.Arg("file", "input file with samples data, default is (../../testdata/20k.series)").Default("../../testdata/20k.series").String()
+		listCmd              = cli.Command("ls", "list db blocks")
+		listPath             = listCmd.Arg("db path", "database path").Default("benchout/storage").String()
 	)
 
 	switch kingpin.MustParse(cli.Parse(os.Args[1:])) {
@@ -53,6 +55,12 @@ func main() {
 			samplesFile: *benchSamplesFile,
 		}
 		wb.run()
+	case listCmd.FullCommand():
+		db, err := tsdb.Open(*listPath, nil, nil, nil)
+		if err != nil {
+			exitWithError(err)
+		}
+		fmt.Println(db.PrintBlocks())
 	}
 	flag.CommandLine.Set("log.level", "debug")
 }

--- a/cmd/tsdb/main.go
+++ b/cmd/tsdb/main.go
@@ -44,7 +44,7 @@ func main() {
 		benchWriteNumMetrics = benchWriteCmd.Flag("metrics", "number of metrics to read").Default("10000").Int()
 		benchSamplesFile     = benchWriteCmd.Arg("file", "input file with samples data, default is (../../testdata/20k.series)").Default("../../testdata/20k.series").String()
 		listCmd              = cli.Command("ls", "list db blocks")
-		listPath             = listCmd.Arg("db path", "database path").Default("benchout/storage").String()
+		listPath             = listCmd.Arg("db path", "database path (default is benchout/storage)").Default("benchout/storage").String()
 	)
 
 	switch kingpin.MustParse(cli.Parse(os.Args[1:])) {
@@ -60,7 +60,7 @@ func main() {
 		if err != nil {
 			exitWithError(err)
 		}
-		fmt.Println(db.PrintBlocks())
+		db.PrintBlocks()
 	}
 	flag.CommandLine.Set("log.level", "debug")
 }

--- a/db.go
+++ b/db.go
@@ -228,27 +228,6 @@ func (db *DB) Dir() string {
 	return db.dir
 }
 
-func (db *DB) PrintBlocks() {
-	db.mtx.RLock()
-	defer db.mtx.RUnlock()
-
-	tw := GetNewTabWriter(os.Stdout)
-	defer tw.Flush()
-
-	fmt.Fprintln(tw, "BLOCK ULID\tMIN TIME\tMAX TIME\tNUM SAMPLES\tNUM CHUNKS\tNUM SERIES")
-	for _, b := range db.blocks {
-		fmt.Fprintf(tw,
-			"%v\t%v\t%v\t%v\t%v\t%v\n",
-			b.Meta().ULID,
-			b.Meta().MinTime,
-			b.Meta().MaxTime,
-			b.Meta().Stats.NumSamples,
-			b.Meta().Stats.NumChunks,
-			b.Meta().Stats.NumSeries,
-		)
-	}
-}
-
 func (db *DB) run() {
 	defer close(db.donec)
 

--- a/db.go
+++ b/db.go
@@ -38,7 +38,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/tsdb/chunks"
 	"github.com/prometheus/tsdb/labels"
-	"github.com/ryanuber/columnize"
 )
 
 // DefaultOptions used for the DB. They are sane for setups using
@@ -229,23 +228,25 @@ func (db *DB) Dir() string {
 	return db.dir
 }
 
-func (db *DB) PrintBlocks() string {
+func (db *DB) PrintBlocks() {
 	db.mtx.RLock()
 	defer db.mtx.RUnlock()
 
-	var output []string
-	output = append(output, "BLOCK ULID | MIN TIME | MAX TIME | NUM SAMPLES | NUM CHUNKS | NUM SERIES")
+	tw := GetNewTabWriter(os.Stdout)
+	defer tw.Flush()
+
+	fmt.Fprintln(tw, "BLOCK ULID\tMIN TIME\tMAX TIME\tNUM SAMPLES\tNUM CHUNKS\tNUM SERIES")
 	for _, b := range db.blocks {
-		output = append(output, fmt.Sprintf("%v | %v | %v | %v | %v | %v",
+		fmt.Fprintf(tw,
+			"%v\t%v\t%v\t%v\t%v\t%v\n",
 			b.Meta().ULID,
 			b.Meta().MinTime,
 			b.Meta().MaxTime,
 			b.Meta().Stats.NumSamples,
 			b.Meta().Stats.NumChunks,
 			b.Meta().Stats.NumSeries,
-		))
+		)
 	}
-	return columnize.SimpleFormat(output)
 }
 
 func (db *DB) run() {

--- a/tabwriter.go
+++ b/tabwriter.go
@@ -1,0 +1,18 @@
+package tsdb
+
+import (
+	"io"
+	"text/tabwriter"
+)
+
+const (
+	minwidth = 0
+	tabwidth = 0
+	padding  = 2
+	padchar  = ' '
+	flags    = 0
+)
+
+func GetNewTabWriter(output io.Writer) *tabwriter.Writer {
+	return tabwriter.NewWriter(output, minwidth, tabwidth, padding, padchar, flags)
+}


### PR DESCRIPTION
I've added an `ls` command to the tsdb cli for listing blocks in the DB (https://github.com/prometheus/tsdb/issues/107). It uses [github.com/ryanuber/columnize](url) for printing tabular.

Example output of `tsdb ls`:
```
BLOCK ULID                  MIN TIME  MAX TIME  NUM SAMPLES  NUM CHUNKS  NUM SERIES
01BVCQAJVXZA5DFKWV6DRYE9W3  0         7200000   35900000     300000      100000
01BVCQAT7894QCN38QV8DVGPWJ  7200000   14400000  36000000     300000      100000
01BVCQB11494K3ZS7MDXDPRP4B  14400000  21600000  36000000     300000      100000
```