### PR TITLE
Add more verbose error handling for closing, reduce locking

### DIFF
--- a/chunks.go
+++ b/chunks.go
@@ -21,9 +21,9 @@ import (
 	"io"
 	"os"
 
-	"github.com/prometheus/tsdb/fileutil"
 	"github.com/pkg/errors"
 	"github.com/prometheus/tsdb/chunks"
+	"github.com/prometheus/tsdb/fileutil"
 )
 
 const (

--- a/db.go
+++ b/db.go
@@ -30,7 +30,6 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
-	"github.com/prometheus/tsdb/fileutil"
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/nightlyone/lockfile"
@@ -38,6 +37,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/tsdb/chunks"
+	"github.com/prometheus/tsdb/fileutil"
 	"github.com/prometheus/tsdb/labels"
 )
 
@@ -105,7 +105,7 @@ type DB struct {
 
 	// Mutex for that must be held when modifying the general block layout.
 	mtx    sync.RWMutex
-	blocks []DiskBlock
+	blocks []*Block
 
 	head *Head
 
@@ -431,7 +431,7 @@ func retentionCutoff(dir string, mint int64) (bool, error) {
 	return changes, fileutil.Fsync(df)
 }
 
-func (db *DB) getBlock(id ulid.ULID) (DiskBlock, bool) {
+func (db *DB) getBlock(id ulid.ULID) (*Block, bool) {
 	for _, b := range db.blocks {
 		if b.Meta().ULID == id {
 			return b, true
@@ -456,7 +456,7 @@ func (db *DB) reload() (err error) {
 		return errors.Wrap(err, "find blocks")
 	}
 	var (
-		blocks []DiskBlock
+		blocks []*Block
 		exist  = map[ulid.ULID]struct{}{}
 	)
 
@@ -468,7 +468,7 @@ func (db *DB) reload() (err error) {
 
 		b, ok := db.getBlock(meta.ULID)
 		if !ok {
-			b, err = newPersistedBlock(dir, db.chunkPool)
+			b, err = OpenBlock(dir, db.chunkPool)
 			if err != nil {
 				return errors.Wrapf(err, "open block %s", dir)
 			}
@@ -505,7 +505,7 @@ func (db *DB) reload() (err error) {
 	return errors.Wrap(db.head.Truncate(maxt), "head truncate failed")
 }
 
-func validateBlockSequence(bs []DiskBlock) error {
+func validateBlockSequence(bs []*Block) error {
 	if len(bs) == 0 {
 		return nil
 	}
@@ -521,13 +521,19 @@ func validateBlockSequence(bs []DiskBlock) error {
 	return nil
 }
 
-func (db *DB) Blocks() []DiskBlock {
+func (db *DB) String() string {
+	return "HEAD"
+}
+
+// Blocks returns the databases persisted blocks.
+func (db *DB) Blocks() []*Block {
 	db.mtx.RLock()
 	defer db.mtx.RUnlock()
 
 	return db.blocks
 }
 
+// Head returns the databases's head.
 func (db *DB) Head() *Head {
 	return db.head
 }
@@ -587,41 +593,42 @@ func (db *DB) Snapshot(dir string) error {
 	db.cmtx.Lock()
 	defer db.cmtx.Unlock()
 
-	db.mtx.RLock()
-	defer db.mtx.RUnlock()
-
-	for _, b := range db.blocks {
+	for _, b := range db.Blocks() {
 		level.Info(db.logger).Log("msg", "snapshotting block", "block", b)
 
 		if err := b.Snapshot(dir); err != nil {
 			return errors.Wrap(err, "error snapshotting headblock")
 		}
 	}
-
 	return db.compactor.Write(dir, db.head, db.head.MinTime(), db.head.MaxTime())
 }
 
 // Querier returns a new querier over the data partition for the given time range.
 // A goroutine must not handle more than one open Querier.
-func (db *DB) Querier(mint, maxt int64) Querier {
-	db.mtx.RLock()
+func (db *DB) Querier(mint, maxt int64) (Querier, error) {
+	var blocks []BlockReader
 
-	blocks := db.blocksForInterval(mint, maxt)
+	for _, b := range db.Blocks() {
+		m := b.Meta()
+		if intervalOverlap(mint, maxt, m.MinTime, m.MaxTime) {
+			blocks = append(blocks, b)
+		}
+	}
+	if maxt >= db.head.MinTime() {
+		blocks = append(blocks, db.head)
+	}
 
 	sq := &querier{
 		blocks: make([]Querier, 0, len(blocks)),
-		db:     db,
 	}
 	for _, b := range blocks {
-		sq.blocks = append(sq.blocks, &blockQuerier{
-			mint:       mint,
-			maxt:       maxt,
-			index:      b.Index(),
-			chunks:     b.Chunks(),
-			tombstones: b.Tombstones(),
-		})
+		q, err := NewBlockQuerier(b, mint, maxt)
+		if err != nil {
+			return nil, errors.Wrapf(err, "open querier for block %s", b)
+		}
+		sq.blocks = append(sq.blocks, q)
 	}
-	return sq
+	return sq, nil
 }
 
 func rangeForTimestamp(t int64, width int64) (mint, maxt int64) {
@@ -634,28 +641,22 @@ func (db *DB) Delete(mint, maxt int64, ms ...labels.Matcher) error {
 	db.cmtx.Lock()
 	defer db.cmtx.Unlock()
 
-	db.mtx.Lock()
-	defer db.mtx.Unlock()
-
 	var g errgroup.Group
 
-	for _, b := range db.blocks {
+	for _, b := range db.Blocks() {
 		m := b.Meta()
 		if intervalOverlap(mint, maxt, m.MinTime, m.MaxTime) {
-			g.Go(func(b DiskBlock) func() error {
+			g.Go(func(b *Block) func() error {
 				return func() error { return b.Delete(mint, maxt, ms...) }
 			}(b))
 		}
 	}
-
 	g.Go(func() error {
 		return db.head.Delete(mint, maxt, ms...)
 	})
-
 	if err := g.Wait(); err != nil {
 		return err
 	}
-
 	return nil
 }
 
@@ -666,24 +667,6 @@ func intervalOverlap(amin, amax, bmin, bmax int64) bool {
 
 func intervalContains(min, max, t int64) bool {
 	return t >= min && t <= max
-}
-
-// blocksForInterval returns all blocks within the partition that may contain
-// data for the given time range.
-func (db *DB) blocksForInterval(mint, maxt int64) []BlockReader {
-	var bs []BlockReader
-
-	for _, b := range db.blocks {
-		m := b.Meta()
-		if intervalOverlap(mint, maxt, m.MinTime, m.MaxTime) {
-			bs = append(bs, b)
-		}
-	}
-	if maxt >= db.head.MinTime() {
-		bs = append(bs, db.head)
-	}
-
-	return bs
 }
 
 func isBlockDir(fi os.FileInfo) bool {

--- a/db_test.go
+++ b/db_test.go
@@ -68,7 +68,8 @@ func TestDataAvailableOnlyAfterCommit(t *testing.T) {
 	_, err := app.Add(labels.FromStrings("foo", "bar"), 0, 0)
 	require.NoError(t, err)
 
-	querier := db.Querier(0, 1)
+	querier, err := db.Querier(0, 1)
+	require.NoError(t, err)
 	seriesSet := readSeriesSet(t, querier.Select(labels.NewEqualMatcher("foo", "bar")))
 
 	require.Equal(t, seriesSet, map[string][]sample{})
@@ -77,7 +78,8 @@ func TestDataAvailableOnlyAfterCommit(t *testing.T) {
 	err = app.Commit()
 	require.NoError(t, err)
 
-	querier = db.Querier(0, 1)
+	querier, err = db.Querier(0, 1)
+	require.NoError(t, err)
 	defer querier.Close()
 
 	seriesSet = readSeriesSet(t, querier.Select(labels.NewEqualMatcher("foo", "bar")))
@@ -96,7 +98,8 @@ func TestDataNotAvailableAfterRollback(t *testing.T) {
 	err = app.Rollback()
 	require.NoError(t, err)
 
-	querier := db.Querier(0, 1)
+	querier, err := db.Querier(0, 1)
+	require.NoError(t, err)
 	defer querier.Close()
 
 	seriesSet := readSeriesSet(t, querier.Select(labels.NewEqualMatcher("foo", "bar")))
@@ -140,7 +143,9 @@ func TestDBAppenderAddRef(t *testing.T) {
 
 	require.NoError(t, app2.Commit())
 
-	q := db.Querier(0, 200)
+	q, err := db.Querier(0, 200)
+	require.NoError(t, err)
+
 	res := readSeriesSet(t, q.Select(labels.NewEqualMatcher("a", "b")))
 
 	require.Equal(t, map[string][]sample{
@@ -190,7 +195,9 @@ Outer:
 		}
 
 		// Compare the result.
-		q := db.Querier(0, numSamples)
+		q, err := db.Querier(0, numSamples)
+		require.NoError(t, err)
+
 		res := q.Select(labels.NewEqualMatcher("a", "b"))
 
 		expSamples := make([]sample, 0, len(c.remaint))
@@ -284,7 +291,9 @@ func TestSkippingInvalidValuesInSameTxn(t *testing.T) {
 	require.NoError(t, app.Commit())
 
 	// Make sure the right value is stored.
-	q := db.Querier(0, 10)
+	q, err := db.Querier(0, 10)
+	require.NoError(t, err)
+
 	ss := q.Select(labels.NewEqualMatcher("a", "b"))
 	ssMap := readSeriesSet(t, ss)
 
@@ -302,7 +311,9 @@ func TestSkippingInvalidValuesInSameTxn(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, app.Commit())
 
-	q = db.Querier(0, 10)
+	q, err = db.Querier(0, 10)
+	require.NoError(t, err)
+
 	ss = q.Select(labels.NewEqualMatcher("a", "b"))
 	ssMap = readSeriesSet(t, ss)
 
@@ -336,7 +347,8 @@ func TestDB_Snapshot(t *testing.T) {
 	db, err = Open(snap, nil, nil, nil)
 	require.NoError(t, err)
 
-	querier := db.Querier(mint, mint+1000)
+	querier, err := db.Querier(mint, mint+1000)
+	require.NoError(t, err)
 	defer querier.Close()
 
 	// sum values
@@ -485,7 +497,9 @@ func TestDB_e2e(t *testing.T) {
 				}
 			}
 
-			q := db.Querier(mint, maxt)
+			q, err := db.Querier(mint, maxt)
+			require.NoError(t, err)
+
 			ss := q.Select(qry.ms...)
 
 			result := map[string][]sample{}

--- a/head_test.go
+++ b/head_test.go
@@ -322,7 +322,8 @@ Outer:
 		}
 
 		// Compare the result.
-		q := NewBlockQuerier(head.Index(), head.Chunks(), head.Tombstones(), head.MinTime(), head.MaxTime())
+		q, err := NewBlockQuerier(head, head.MinTime(), head.MaxTime())
+		require.NoError(t, err)
 		res := q.Select(labels.NewEqualMatcher("a", "b"))
 
 		expSamples := make([]sample, 0, len(c.remaint))

--- a/index.go
+++ b/index.go
@@ -19,14 +19,14 @@ import (
 	"fmt"
 	"hash"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
-	"math"
 
-	"github.com/prometheus/tsdb/fileutil"
 	"github.com/pkg/errors"
+	"github.com/prometheus/tsdb/fileutil"
 	"github.com/prometheus/tsdb/labels"
 )
 

--- a/index_test.go
+++ b/index_test.go
@@ -40,12 +40,15 @@ type mockIndex struct {
 }
 
 func newMockIndex() mockIndex {
-	return mockIndex{
+	ix := mockIndex{
 		series:     make(map[uint64]series),
 		labelIndex: make(map[string][]string),
 		postings:   newMemPostings(),
 		symbols:    make(map[string]struct{}),
 	}
+	ix.postings.ensureOrder()
+
+	return ix
 }
 
 func (m mockIndex) Symbols() (map[string]struct{}, error) {
@@ -277,6 +280,7 @@ func TestPersistence_index_e2e(t *testing.T) {
 		postings = newMemPostings()
 		values   = map[string]stringset{}
 	)
+	postings.ensureOrder()
 
 	mi := newMockIndex()
 

--- a/tombstones.go
+++ b/tombstones.go
@@ -33,9 +33,11 @@ const (
 	tombstoneFormatV1 = 1
 )
 
-// TombstoneReader is the iterator over tombstones.
+// TombstoneReader gives access to tombstone intervals by series reference.
 type TombstoneReader interface {
 	Get(ref uint64) Intervals
+
+	Close() error
 }
 
 func writeTombstoneFile(dir string, tr tombstoneReader) error {
@@ -152,6 +154,10 @@ func (t tombstoneReader) Get(ref uint64) Intervals {
 
 func (t tombstoneReader) add(ref uint64, itv Interval) {
 	t[ref] = t[ref].add(itv)
+}
+
+func (tombstoneReader) Close() error {
+	return nil
 }
 
 // Interval represents a single time-interval.


### PR DESCRIPTION
This commit introduces error returns in various places and is explicit
about closing persisted blocks.
{Index,Chunk,Tombstone}Readers are more consistent about their Close()
method. Whenever a reader is retrieved, the corresponding close method
must eventually be called. We use this to track pending readers against
persisted blocks.

Querier's against the DB no longer hold a read lock for their entire
lifecycle. This avoids long running queriers to starve new ones when we
have to acquire a write lock when reloading blocks.

@grobie @Gouthamve 

This is basically just making the APIs a bit safer and shifting locking a bit. Still want to take this through a prombench run first though.