### PR TITLE
Fix race in symbol table re-creation

### DIFF
--- a/head.go
+++ b/head.go
@@ -665,7 +665,7 @@ func (h *Head) gc() {
 	// Rebuild symbols and label value indices from what is left in the postings terms.
 	h.postings.mtx.RLock()
 
-	symbols := make(map[string]struct{}, len(h.symbols))
+	symbols := make(map[string]struct{})
 	values := make(map[string]stringset, len(h.values))
 
 	for t := range h.postings.m {


### PR DESCRIPTION
Fixes #177 

Relatively trivial and shouldn't have caused any harm. As the allocations are pretty minor, this was probably not worth pre-allocating to begin with.