### PR TITLE
Fix dangling chunk reference panic

### DIFF
--- a/chunks/chunk.go
+++ b/chunks/chunk.go
@@ -69,6 +69,17 @@ type Iterator interface {
 	Next() bool
 }
 
+// NewNopIterator returns a new chunk iterator that does not hold any data.
+func NewNopIterator() Iterator {
+	return nopIterator{}
+}
+
+type nopIterator struct{}
+
+func (nopIterator) At() (int64, float64) { return 0, 0 }
+func (nopIterator) Next() bool           { return false }
+func (nopIterator) Err() error           { return nil }
+
 type Pool interface {
 	Put(Chunk) error
 	Get(e Encoding, b []byte) (Chunk, error)

--- a/head.go
+++ b/head.go
@@ -1270,6 +1270,12 @@ func computeChunkEndTime(start, cur, max int64) int64 {
 
 func (s *memSeries) iterator(id int) chunks.Iterator {
 	c := s.chunk(id)
+	// TODO(fabxc): Work around! A querier may have retrieved a pointer to a series' chunk,
+	// which got then garbage collected before it got accessed.
+	// We must ensure to not garbage collect as long as any readers still hold a reference.
+	if c == nil {
+		return chunks.NewNopIterator()
+	}
 
 	if id-s.firstChunkID < len(s.chunks)-1 {
 		return c.chunk.Iterator()

--- a/head.go
+++ b/head.go
@@ -665,7 +665,7 @@ func (h *Head) gc() {
 	// Rebuild symbols and label value indices from what is left in the postings terms.
 	h.postings.mtx.RLock()
 
-	symbols := make(map[string]struct{}, len(h.symbols))
+	symbols := make(map[string]struct{})
 	values := make(map[string]stringset, len(h.values))
 
 	for t := range h.postings.m {


### PR DESCRIPTION
This is just an intermediate fix. It's not perfect and query artefacts may happen. However, this is much better than the panics and their consequences we are seeing currently.

This being pretty straightforward, I think it is worth merging and getting into Prometheus.
The proper fix of the underlying problem is more complex and I'd like to think more about a simple solution rather than bringing in complication that may cause other regressions right now.

@grobie @beorn7 could you take this for a spin on the servers where you saw the issue?