### PR TITLE
Ensure near-empty chunks end at correct boundary

### DIFF
--- a/querier.go
+++ b/querier.go
@@ -535,7 +535,6 @@ func (s *populatedChunkSeries) Next() bool {
 				return false
 			}
 		}
-
 		if len(chks) == 0 {
 			continue
 		}


### PR DESCRIPTION
We were determining a chunk's end time once it was one quarter full to
compute it so all chunks have uniform number of samples.
This accidentally skipped the case where series started near the end of
a chunk range/block and never reached that threshold. As a result they
got persisted but were continued across the range.

This resulted in corrupted persisted data.

@smarterclayton @EdSchouten I believe this is the source of the issue you are seeing. At the very least this seems to reliably fix the unordered and repeated samples that were reported.
It also fixes artefacts of rate() calculations for me. Though mine looked a bit different – but given that a very fundamental invariant is violated in the raw data, I'd expect different shapes of artefacts anyway.

Would you be open to run a version with this and some other recent patches to confirm whether this fixes things? I'd do another RC afterwards.