### PR TITLE
Ensure tsdb can be built on SmartOS/Illumos/Solaris

### DIFF
--- a/db_unix.go
+++ b/db_unix.go
@@ -11,19 +11,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !windows,!plan9,!solaris
+// +build !windows,!plan9
 
 package tsdb
 
 import (
 	"os"
-	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
 func mmap(f *os.File, length int) ([]byte, error) {
-	return syscall.Mmap(int(f.Fd()), 0, length, syscall.PROT_READ, syscall.MAP_SHARED)
+	return unix.Mmap(int(f.Fd()), 0, length, unix.PROT_READ, unix.MAP_SHARED)
 }
 
 func munmap(b []byte) (err error) {
-	return syscall.Munmap(b)
+	return unix.Munmap(b)
 }


### PR DESCRIPTION
Issue: https://github.com/prometheus/tsdb/issues/199

At the moment tsdb cannot be built on Illumos/Solaris due to

- An exclude tag against Solaris is added in db_unix.go
- We use built-in syscall package, which doesn't have nmmap and munmap support

This PR supports build on Illumos/Solaris by remove the Solaris exclude tag in db_unix.go
At the same time use golang.org/x/sys/unix package instead of syscall package, since it has Solaris nmmap and munmap implementation.

I'm able to get a succeeded build on SmartOS

```
[root@prometheus2 ~/go/src/github.com/prometheus/tsdb]# uname -a
SunOS prometheus2 5.11 joyent_20170105T023718Z i86pc i386 i86pc Solaris
[root@prometheus2 ~/go/src/github.com/prometheus/tsdb]# go test
level=warn msg="invalid segment file detected, truncating WAL" err="invalid magic header 1020304 in \"/tmp/test_wal_log_restore159904583/000001\"" file=/tmp/test_wal_log_restore159904583/000001
level=error msg="WAL corruption detected; truncating" err="invalid checksum length 3" file=/tmp/test_corrupted980156410/000001 pos=44
level=error msg="WAL corruption detected; truncating" err="invalid entry body size 22" file=/tmp/test_corrupted203800849/000001 pos=44
level=error msg="WAL corruption detected; truncating" err="unexpected CRC32 checksum 1d4d95cc, want 7c1a52ff" file=/tmp/test_corrupted594179900/000001 pos=44
level=error msg="WAL corruption detected; truncating" err="unexpected CRC32 checksum 7c1a52ff, want 1020304" file=/tmp/test_corrupted091899243/000001 pos=44
PASS
ok      github.com/prometheus/tsdb      7.005s
```