### PR TITLE
index: simplify checksum validation

### DIFF
--- a/encoding_helpers.go
+++ b/encoding_helpers.go
@@ -3,6 +3,7 @@ package tsdb
 import (
 	"encoding/binary"
 	"hash"
+	"hash/crc32"
 	"unsafe"
 )
 
@@ -76,6 +77,11 @@ func (d *decbuf) uvarint() int      { return int(d.uvarint64()) }
 func (d *decbuf) uvarint32() uint32 { return uint32(d.uvarint64()) }
 func (d *decbuf) be32int() int      { return int(d.be32()) }
 func (d *decbuf) be64int64() int64  { return int64(d.be64()) }
+
+// crc32 returns a CRC32 checksum over the remaining bytes.
+func (d *decbuf) crc32() uint32 {
+	return crc32.Checksum(d.b, castagnoliTable)
+}
 
 func (d *decbuf) uvarintStr() string {
 	l := d.uvarint64()


### PR DESCRIPTION
We can just take a CRC32 over everything we want to decode beforehand. This way we don't have to track offsets and reconstruct the decoded byte range in checkCRC.