### PR TITLE
Add explicit error to Querier.Select

### DIFF
--- a/block.go
+++ b/block.go
@@ -285,7 +285,10 @@ func (pb *Block) Delete(mint, maxt int64, ms ...labels.Matcher) error {
 	}
 
 	pr := newPostingsReader(pb.indexr)
-	p, absent := pr.Select(ms...)
+	p, absent, err := pr.Select(ms...)
+	if err != nil {
+		return errors.Wrap(err, "select series")
+	}
 
 	ir := pb.indexr
 

--- a/head.go
+++ b/head.go
@@ -575,7 +575,10 @@ func (h *Head) Delete(mint, maxt int64, ms ...labels.Matcher) error {
 	ir := h.indexRange(mint, maxt)
 
 	pr := newPostingsReader(ir)
-	p, absent := pr.Select(ms...)
+	p, absent, err := pr.Select(ms...)
+	if err != nil {
+		return errors.Wrap(err, "select series")
+	}
 
 	var stones []Stone
 

--- a/head_test.go
+++ b/head_test.go
@@ -328,7 +328,8 @@ Outer:
 		// Compare the result.
 		q, err := NewBlockQuerier(head, head.MinTime(), head.MaxTime())
 		require.NoError(t, err)
-		res := q.Select(labels.NewEqualMatcher("a", "b"))
+		res, err := q.Select(labels.NewEqualMatcher("a", "b"))
+		require.NoError(t, err)
 
 		expSamples := make([]sample, 0, len(c.remaint))
 		for _, ts := range c.remaint {

--- a/postings.go
+++ b/postings.go
@@ -165,6 +165,11 @@ func (e errPostings) Err() error       { return e.err }
 
 var emptyPostings = errPostings{}
 
+// EmptyPostings returns a postings list that's always empty.
+func EmptyPostings() Postings {
+	return emptyPostings
+}
+
 // Intersect returns a new postings list over the intersection of the
 // input postings.
 func Intersect(its ...Postings) Postings {

--- a/querier_test.go
+++ b/querier_test.go
@@ -460,7 +460,8 @@ Outer:
 			maxt: c.maxt,
 		}
 
-		res := querier.Select(c.ms...)
+		res, err := querier.Select(c.ms...)
+		require.NoError(t, err)
 
 		for {
 			eok, rok := c.exp.Next(), res.Next()
@@ -632,7 +633,8 @@ Outer:
 			maxt: c.maxt,
 		}
 
-		res := querier.Select(c.ms...)
+		res, err := querier.Select(c.ms...)
+		require.NoError(t, err)
 
 		for {
 			eok, rok := c.exp.Next(), res.Next()
@@ -1228,7 +1230,7 @@ func BenchmarkMergedSeriesSet(b *testing.B) {
 
 	sel = func(sets []SeriesSet) SeriesSet {
 		if len(sets) == 0 {
-			return nopSeriesSet{}
+			return EmptySeriesSet()
 		}
 		if len(sets) == 1 {
 			return sets[0]


### PR DESCRIPTION
This has been a frequent source of debugging pain since errors are
potentially delayed to a much later point. They bubble up in an
unrelated execution path.

Originally seemed like a neat idea – it was not :)