### PR TITLE
Partial chunk deletions are not compacted away

### DIFF
--- a/db.go
+++ b/db.go
@@ -612,7 +612,7 @@ func (db *DB) Snapshot(dir string) error {
 		level.Info(db.logger).Log("msg", "snapshotting block", "block", b)
 
 		if err := b.Snapshot(dir); err != nil {
-			return errors.Wrap(err, "error snapshotting headblock")
+			return errors.Wrapf(err, "error snapshotting block: %s", b.Dir())
 		}
 	}
 	return db.compactor.Write(dir, db.head, db.head.MinTime(), db.head.MaxTime())


### PR DESCRIPTION
This is a bug when a partial chunk is deleted. We are creating a new chunk without the deletions but assigned it to a copied struct, essentially dropping it to the floor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prometheus/tsdb/209)
<!-- Reviewable:end -->
