### PR TITLE
Order postings lists in index file by key

### DIFF
--- a/compact.go
+++ b/compact.go
@@ -589,7 +589,7 @@ func (c *LeveledCompactor) populateBlock(blocks []BlockReader, meta *BlockMeta, 
 		}
 	}
 
-	for l := range postings.m {
+	for _, l := range postings.sortedKeys() {
 		if err := indexw.WritePostings(l.Name, l.Value, postings.get(l.Name, l.Value)); err != nil {
 			return errors.Wrap(err, "write postings")
 		}

--- a/postings.go
+++ b/postings.go
@@ -50,6 +50,25 @@ func newUnorderedMemPostings() *memPostings {
 	}
 }
 
+// sortedKeys returns a list of sorted label keys of the postings.
+func (p *memPostings) sortedKeys() []labels.Label {
+	p.mtx.RLock()
+	keys := make([]labels.Label, 0, len(p.m))
+
+	for l := range p.m {
+		keys = append(keys, l)
+	}
+	p.mtx.RUnlock()
+
+	sort.Slice(keys, func(i, j int) bool {
+		if d := strings.Compare(keys[i].Name, keys[j].Name); d != 0 {
+			return d < 0
+		}
+		return keys[i].Value < keys[j].Value
+	})
+	return keys
+}
+
 // Postings returns an iterator over the postings list for s.
 func (p *memPostings) get(name, value string) Postings {
 	p.mtx.RLock()


### PR DESCRIPTION
Aligning postings list for similar keys close to each other improves
page cache hit rates in typical queries that select postings for
multiple label pairs with the same name.