### PR TITLE
Fdatasync on read to flush any unflushed data.

### DIFF
--- a/block_test.go
+++ b/block_test.go
@@ -46,7 +46,7 @@ func createEmptyBlock(t *testing.T, dir string) *Block {
 
 	Ok(t, os.MkdirAll(chunkDir(dir), 0777))
 
-	Ok(t, writeTombstoneFile(dir, newEmptyTombstoneReader()))
+	Ok(t, writeTombstoneFile(dir, EmptyTombstoneReader()))
 
 	b, err := OpenBlock(dir, nil)
 	Ok(t, err)

--- a/wal.go
+++ b/wal.go
@@ -523,6 +523,12 @@ func (w *SegmentWAL) openSegmentFile(name string) (*os.File, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// Sync the file first to see any unflushed buffers.
+	if err := fileutil.Fdatasync(f); err != nil {
+		return nil, err
+	}
+
 	metab := make([]byte, 8)
 
 	// If there is an error, we need close f for platform windows before gc.


### PR DESCRIPTION
This is to handle partial writes from a previous crash.

Fixes prometheus/prometheus#3487

Signed-off-by: Goutham Veeramachaneni <cs14btech11014@iith.ac.in>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prometheus/tsdb/218)
<!-- Reviewable:end -->
