### PR TITLE
index: reduce empty postings trees

### DIFF
--- a/index/postings_test.go
+++ b/index/postings_test.go
@@ -532,3 +532,14 @@ func TestIntersectWithMerge(t *testing.T) {
 	testutil.Ok(t, err)
 	testutil.Equals(t, []uint64{30}, res)
 }
+
+func TestReduceToEmptyPostings(t *testing.T) {
+	a := newListPostings([]uint64{1, 2, 3})
+	b := newListPostings([]uint64{2, 3, 4})
+	c := EmptyPostings()
+
+	testutil.Assert(t, Intersect(a, b, c) == EmptyPostings(), "was not empty postings")
+	testutil.Assert(t, Merge(a, b, c) != EmptyPostings(), "should not be empty postings")
+	testutil.Assert(t, Merge(c, c, c) == EmptyPostings(), "was not empty postings")
+	testutil.Assert(t, Without(c, a) == EmptyPostings(), "was not empty postings")
+}

--- a/querier.go
+++ b/querier.go
@@ -204,6 +204,7 @@ func (q *blockQuerier) Close() error {
 // PostingsForMatchers assembles a single postings iterator against the index reader
 // based on the given matchers. It returns a list of label names that must be manually
 // checked to not exist in series the postings list points to.
+// It returns EmptyPostings() if it can be determined beforehand that no results will be found.
 func PostingsForMatchers(ix IndexReader, ms ...labels.Matcher) (index.Postings, error) {
 	var its []index.Postings
 


### PR DESCRIPTION
If a query has multiple matchers that are intersected, we can potentially reduce the postings tree to the `EmptyPostings()` beforehand. This way we don't have to hit or preload any of the underlying postings lists at all.

This is mostly relevant for `Intersect()` but I added it for the other ones too for consistency.