### PR TITLE
[WIP] Add benchmarks

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -101,25 +101,10 @@ func createBlock(series []labels.Labels) (*Block, func(), error) {
 	return block, func() { os.RemoveAll(tmpdir) }, nil
 }
 
-func BenchmarkInMemQueries_Series_1M_EQSelector_1_NoExpansion(b *testing.B) {
-	series := genSeries(6, 10)
-
-	benchInMemQuery(b, series, labels.Selector{labels.NewEqualMatcher("label-1", "value-5")}, false)
-}
-
 func BenchmarkInMemQueries_Series_1M_EQSelector_1_Expansion(b *testing.B) {
 	series := genSeries(6, 10)
 
 	benchInMemQuery(b, series, labels.Selector{labels.NewEqualMatcher("label-1", "value-5")}, true)
-}
-
-func BenchmarkInMemQueries_Series_1M_EQSelector_2_NoExpansion(b *testing.B) {
-	series := genSeries(6, 10)
-
-	benchInMemQuery(b, series, labels.Selector{
-		labels.NewEqualMatcher("label-1", "value-5"),
-		labels.NewEqualMatcher("label-2", "value-4"),
-	}, false)
 }
 
 func BenchmarkInMemQueries_Series_1M_EQSelector_2_Expansion(b *testing.B) {
@@ -129,16 +114,6 @@ func BenchmarkInMemQueries_Series_1M_EQSelector_2_Expansion(b *testing.B) {
 		labels.NewEqualMatcher("label-1", "value-5"),
 		labels.NewEqualMatcher("label-2", "value-4"),
 	}, true)
-}
-
-func BenchmarkInMemQueries_Series_1M_EQSelector_3_NoExpansion(b *testing.B) {
-	series := genSeries(6, 10)
-
-	benchInMemQuery(b, series, labels.Selector{
-		labels.NewEqualMatcher("label-1", "value-5"),
-		labels.NewEqualMatcher("label-2", "value-4"),
-		labels.NewEqualMatcher("label-3", "value-4"),
-	}, false)
 }
 
 func BenchmarkInMemQueries_Series_1M_EQSelector_3_Expansion(b *testing.B) {
@@ -151,25 +126,10 @@ func BenchmarkInMemQueries_Series_1M_EQSelector_3_Expansion(b *testing.B) {
 	}, true)
 }
 
-func BenchmarkPersistedQueries_Series_1M_EQSelector_1_NoExpansion(b *testing.B) {
-	series := genSeries(6, 10)
-
-	benchPersistedQuery(b, series, labels.Selector{labels.NewEqualMatcher("label-1", "value-5")}, false)
-}
-
 func BenchmarkPersistedQueries_Series_1M_EQSelector_1_Expansion(b *testing.B) {
 	series := genSeries(6, 10)
 
 	benchPersistedQuery(b, series, labels.Selector{labels.NewEqualMatcher("label-1", "value-5")}, true)
-}
-
-func BenchmarkPersistedQueries_Series_1M_EQSelector_2_NoExpansion(b *testing.B) {
-	series := genSeries(6, 10)
-
-	benchPersistedQuery(b, series, labels.Selector{
-		labels.NewEqualMatcher("label-1", "value-5"),
-		labels.NewEqualMatcher("label-2", "value-4"),
-	}, false)
 }
 
 func BenchmarkPersistedQueries_Series_1M_EQSelector_2_Expansion(b *testing.B) {
@@ -179,16 +139,6 @@ func BenchmarkPersistedQueries_Series_1M_EQSelector_2_Expansion(b *testing.B) {
 		labels.NewEqualMatcher("label-1", "value-5"),
 		labels.NewEqualMatcher("label-2", "value-4"),
 	}, true)
-}
-
-func BenchmarkPersistedQueries_Series_1M_EQSelector_3_NoExpansion(b *testing.B) {
-	series := genSeries(6, 10)
-
-	benchPersistedQuery(b, series, labels.Selector{
-		labels.NewEqualMatcher("label-1", "value-5"),
-		labels.NewEqualMatcher("label-2", "value-4"),
-		labels.NewEqualMatcher("label-3", "value-4"),
-	}, false)
 }
 
 func BenchmarkPersistedQueries_Series_1M_EQSelector_3_Expansion(b *testing.B) {
@@ -201,25 +151,10 @@ func BenchmarkPersistedQueries_Series_1M_EQSelector_3_Expansion(b *testing.B) {
 	}, true)
 }
 
-func BenchmarkInMemQueries_Series_1M_RESelector_1_NoExpansion(b *testing.B) {
-	series := genSeries(3, 100)
-
-	benchInMemQuery(b, series, labels.Selector{labels.NewMustRegexpMatcher("label-2", "value-.*0")}, false)
-}
-
 func BenchmarkInMemQueries_Series_1M_RESelector_1_Expansion(b *testing.B) {
 	series := genSeries(3, 100)
 
 	benchInMemQuery(b, series, labels.Selector{labels.NewMustRegexpMatcher("label-2", "value-.*0")}, true)
-}
-
-func BenchmarkInMemQueries_Series_1M_RESelector_2_NoExpansion(b *testing.B) {
-	series := genSeries(3, 100)
-
-	benchInMemQuery(b, series, labels.Selector{
-		labels.NewMustRegexpMatcher("label-1", "value-.*0"),
-		labels.NewMustRegexpMatcher("label-2", "value-4.*"),
-	}, false)
 }
 
 func BenchmarkInMemQueries_Series_1M_RESelector_2_Expansion(b *testing.B) {
@@ -229,16 +164,6 @@ func BenchmarkInMemQueries_Series_1M_RESelector_2_Expansion(b *testing.B) {
 		labels.NewMustRegexpMatcher("label-1", "value-.*0"),
 		labels.NewMustRegexpMatcher("label-2", "value-4.*"),
 	}, true)
-}
-
-func BenchmarkInMemQueries_Series_1M_RESelector_3_NoExpansion(b *testing.B) {
-	series := genSeries(3, 100)
-
-	benchInMemQuery(b, series, labels.Selector{
-		labels.NewMustRegexpMatcher("label-0", "value-5.*"),
-		labels.NewMustRegexpMatcher("label-1", "value-.*4"),
-		labels.NewMustRegexpMatcher("label-2", "value-.*4"),
-	}, false)
 }
 
 func BenchmarkInMemQueries_Series_1M_RESelector_3_Expansion(b *testing.B) {
@@ -251,25 +176,10 @@ func BenchmarkInMemQueries_Series_1M_RESelector_3_Expansion(b *testing.B) {
 	}, true)
 }
 
-func BenchmarkPersistedQueries_Series_1M_RESelector_1_NoExpansion(b *testing.B) {
-	series := genSeries(3, 100)
-
-	benchPersistedQuery(b, series, labels.Selector{labels.NewMustRegexpMatcher("label-2", "value-.*0")}, false)
-}
-
 func BenchmarkPersistedQueries_Series_1M_RESelector_1_Expansion(b *testing.B) {
 	series := genSeries(3, 100)
 
 	benchPersistedQuery(b, series, labels.Selector{labels.NewMustRegexpMatcher("label-2", "value-.*0")}, true)
-}
-
-func BenchmarkPersistedQueries_Series_1M_RESelector_2_NoExpansion(b *testing.B) {
-	series := genSeries(3, 100)
-
-	benchPersistedQuery(b, series, labels.Selector{
-		labels.NewMustRegexpMatcher("label-1", "value-.*0"),
-		labels.NewMustRegexpMatcher("label-2", "value-4.*"),
-	}, false)
 }
 
 func BenchmarkPersistedQueries_Series_1M_RESelector_2_Expansion(b *testing.B) {
@@ -279,16 +189,6 @@ func BenchmarkPersistedQueries_Series_1M_RESelector_2_Expansion(b *testing.B) {
 		labels.NewMustRegexpMatcher("label-1", "value-.*0"),
 		labels.NewMustRegexpMatcher("label-2", "value-4.*"),
 	}, true)
-}
-
-func BenchmarkPersistedQueries_Series_1M_RESelector_3_NoExpansion(b *testing.B) {
-	series := genSeries(3, 100)
-
-	benchPersistedQuery(b, series, labels.Selector{
-		labels.NewMustRegexpMatcher("label-0", "value-5.*"),
-		labels.NewMustRegexpMatcher("label-1", "value-.*4"),
-		labels.NewMustRegexpMatcher("label-2", "value-.*4"),
-	}, false)
 }
 
 func BenchmarkPersistedQueries_Series_1M_RESelector_3_Expansion(b *testing.B) {
@@ -301,169 +201,66 @@ func BenchmarkPersistedQueries_Series_1M_RESelector_3_Expansion(b *testing.B) {
 	}, true)
 }
 
-func BenchmarkPersistedQueries_3Blocks_Series_1M_EQSelector_1_NoExpansion(b *testing.B) {
-	series := genSeries(6, 10)
-
-	block1, deferFunc, err := createBlock(series)
-	testutil.Ok(b, err)
-	defer deferFunc()
-
-	block2, deferFunc, err := createBlock(series)
-	testutil.Ok(b, err)
-	defer deferFunc()
-
-	block3, deferFunc, err := createBlock(series)
-	testutil.Ok(b, err)
-	defer deferFunc()
-
-	q1, err := NewBlockQuerier(block1, 0, 20)
-	testutil.Ok(b, err)
-	q2, err := NewBlockQuerier(block2, 0, 20)
-	testutil.Ok(b, err)
-	q3, err := NewBlockQuerier(block3, 0, 20)
-	testutil.Ok(b, err)
-
-	q := &querier{blocks: []Querier{q1, q2, q3}}
-	benchQuery(b, q, labels.Selector{labels.NewEqualMatcher("label-1", "value-5")}, false)
-}
-
 func BenchmarkPersistedQueries_3Blocks_Series_1M_EQSelector_1_Expansion(b *testing.B) {
 	series := genSeries(6, 10)
 
-	block1, deferFunc, err := createBlock(series)
-	testutil.Ok(b, err)
-	defer deferFunc()
+	qs := []Querier{}
 
-	block2, deferFunc, err := createBlock(series)
-	testutil.Ok(b, err)
-	defer deferFunc()
+	for i := 0; i < 3; i++ {
+		block, deferFunc, err := createBlock(series)
+		testutil.Ok(b, err)
+		defer deferFunc()
 
-	block3, deferFunc, err := createBlock(series)
-	testutil.Ok(b, err)
-	defer deferFunc()
+		q, err := NewBlockQuerier(block, 0, 20)
+		testutil.Ok(b, err)
 
-	q1, err := NewBlockQuerier(block1, 0, 20)
-	testutil.Ok(b, err)
-	q2, err := NewBlockQuerier(block2, 0, 20)
-	testutil.Ok(b, err)
-	q3, err := NewBlockQuerier(block3, 0, 20)
-	testutil.Ok(b, err)
+		qs = append(qs, q)
+	}
 
-	q := &querier{blocks: []Querier{q1, q2, q3}}
+	q := &querier{blocks: qs}
 	benchQuery(b, q, labels.Selector{labels.NewEqualMatcher("label-1", "value-5")}, true)
-}
-
-func BenchmarkPersistedQueries_3Blocks_Series_1M_EQSelector_2_NoExpansion(b *testing.B) {
-	series := genSeries(6, 10)
-
-	block1, deferFunc, err := createBlock(series)
-	testutil.Ok(b, err)
-	defer deferFunc()
-
-	block2, deferFunc, err := createBlock(series)
-	testutil.Ok(b, err)
-	defer deferFunc()
-
-	block3, deferFunc, err := createBlock(series)
-	testutil.Ok(b, err)
-	defer deferFunc()
-
-	q1, err := NewBlockQuerier(block1, 0, 20)
-	testutil.Ok(b, err)
-	q2, err := NewBlockQuerier(block2, 0, 20)
-	testutil.Ok(b, err)
-	q3, err := NewBlockQuerier(block3, 0, 20)
-	testutil.Ok(b, err)
-
-	q := &querier{blocks: []Querier{q1, q2, q3}}
-	benchQuery(b, q, labels.Selector{
-		labels.NewEqualMatcher("label-1", "value-5"),
-		labels.NewEqualMatcher("label-2", "value-4"),
-	}, false)
 }
 
 func BenchmarkPersistedQueries_3Blocks_Series_1M_EQSelector_2_Expansion(b *testing.B) {
 	series := genSeries(6, 10)
 
-	block1, deferFunc, err := createBlock(series)
-	testutil.Ok(b, err)
-	defer deferFunc()
+	qs := []Querier{}
 
-	block2, deferFunc, err := createBlock(series)
-	testutil.Ok(b, err)
-	defer deferFunc()
+	for i := 0; i < 3; i++ {
+		block, deferFunc, err := createBlock(series)
+		testutil.Ok(b, err)
+		defer deferFunc()
 
-	block3, deferFunc, err := createBlock(series)
-	testutil.Ok(b, err)
-	defer deferFunc()
+		q, err := NewBlockQuerier(block, 0, 20)
+		testutil.Ok(b, err)
 
-	q1, err := NewBlockQuerier(block1, 0, 20)
-	testutil.Ok(b, err)
-	q2, err := NewBlockQuerier(block2, 0, 20)
-	testutil.Ok(b, err)
-	q3, err := NewBlockQuerier(block3, 0, 20)
-	testutil.Ok(b, err)
+		qs = append(qs, q)
+	}
 
-	q := &querier{blocks: []Querier{q1, q2, q3}}
+	q := &querier{blocks: qs}
 	benchQuery(b, q, labels.Selector{
 		labels.NewEqualMatcher("label-1", "value-5"),
 		labels.NewEqualMatcher("label-2", "value-4"),
 	}, true)
-}
-
-func BenchmarkPersistedQueries_3Blocks_Series_1M_EQSelector_3_NoExpansion(b *testing.B) {
-	series := genSeries(6, 10)
-
-	block1, deferFunc, err := createBlock(series)
-	testutil.Ok(b, err)
-	defer deferFunc()
-
-	block2, deferFunc, err := createBlock(series)
-	testutil.Ok(b, err)
-	defer deferFunc()
-
-	block3, deferFunc, err := createBlock(series)
-	testutil.Ok(b, err)
-	defer deferFunc()
-
-	q1, err := NewBlockQuerier(block1, 0, 20)
-	testutil.Ok(b, err)
-	q2, err := NewBlockQuerier(block2, 0, 20)
-	testutil.Ok(b, err)
-	q3, err := NewBlockQuerier(block3, 0, 20)
-	testutil.Ok(b, err)
-
-	q := &querier{blocks: []Querier{q1, q2, q3}}
-	benchQuery(b, q, labels.Selector{
-		labels.NewEqualMatcher("label-1", "value-5"),
-		labels.NewEqualMatcher("label-2", "value-4"),
-		labels.NewEqualMatcher("label-3", "value-4"),
-	}, false)
 }
 
 func BenchmarkPersistedQueries_3Blocks_Series_1M_EQSelector_3_Expansion(b *testing.B) {
 	series := genSeries(6, 10)
 
-	block1, deferFunc, err := createBlock(series)
-	testutil.Ok(b, err)
-	defer deferFunc()
+	qs := []Querier{}
 
-	block2, deferFunc, err := createBlock(series)
-	testutil.Ok(b, err)
-	defer deferFunc()
+	for i := 0; i < 3; i++ {
+		block, deferFunc, err := createBlock(series)
+		testutil.Ok(b, err)
+		defer deferFunc()
 
-	block3, deferFunc, err := createBlock(series)
-	testutil.Ok(b, err)
-	defer deferFunc()
+		q, err := NewBlockQuerier(block, 0, 20)
+		testutil.Ok(b, err)
 
-	q1, err := NewBlockQuerier(block1, 0, 20)
-	testutil.Ok(b, err)
-	q2, err := NewBlockQuerier(block2, 0, 20)
-	testutil.Ok(b, err)
-	q3, err := NewBlockQuerier(block3, 0, 20)
-	testutil.Ok(b, err)
+		qs = append(qs, q)
+	}
 
-	q := &querier{blocks: []Querier{q1, q2, q3}}
+	q := &querier{blocks: qs}
 	benchQuery(b, q, labels.Selector{
 		labels.NewEqualMatcher("label-1", "value-5"),
 		labels.NewEqualMatcher("label-2", "value-4"),
@@ -471,111 +268,43 @@ func BenchmarkPersistedQueries_3Blocks_Series_1M_EQSelector_3_Expansion(b *testi
 	}, true)
 }
 
-func BenchmarkPersistedQueries_3Blocks_Series_1M_RESelector_1_NoExpansion(b *testing.B) {
-	series := genSeries(3, 100)
-
-	block1, deferFunc, err := createBlock(series)
-	testutil.Ok(b, err)
-	defer deferFunc()
-
-	block2, deferFunc, err := createBlock(series)
-	testutil.Ok(b, err)
-	defer deferFunc()
-
-	block3, deferFunc, err := createBlock(series)
-	testutil.Ok(b, err)
-	defer deferFunc()
-
-	q1, err := NewBlockQuerier(block1, 0, 20)
-	testutil.Ok(b, err)
-	q2, err := NewBlockQuerier(block2, 0, 20)
-	testutil.Ok(b, err)
-	q3, err := NewBlockQuerier(block3, 0, 20)
-	testutil.Ok(b, err)
-
-	q := &querier{blocks: []Querier{q1, q2, q3}}
-	benchQuery(b, q, labels.Selector{labels.NewMustRegexpMatcher("label-2", "value-.*0")}, false)
-}
-
 func BenchmarkPersistedQueries_3Blocks_Series_1M_RESelector_1_Expansion(b *testing.B) {
 	series := genSeries(3, 100)
 
-	block1, deferFunc, err := createBlock(series)
-	testutil.Ok(b, err)
-	defer deferFunc()
+	qs := []Querier{}
 
-	block2, deferFunc, err := createBlock(series)
-	testutil.Ok(b, err)
-	defer deferFunc()
+	for i := 0; i < 3; i++ {
+		block, deferFunc, err := createBlock(series)
+		testutil.Ok(b, err)
+		defer deferFunc()
 
-	block3, deferFunc, err := createBlock(series)
-	testutil.Ok(b, err)
-	defer deferFunc()
+		q, err := NewBlockQuerier(block, 0, 20)
+		testutil.Ok(b, err)
 
-	q1, err := NewBlockQuerier(block1, 0, 20)
-	testutil.Ok(b, err)
-	q2, err := NewBlockQuerier(block2, 0, 20)
-	testutil.Ok(b, err)
-	q3, err := NewBlockQuerier(block3, 0, 20)
-	testutil.Ok(b, err)
+		qs = append(qs, q)
+	}
 
-	q := &querier{blocks: []Querier{q1, q2, q3}}
+	q := &querier{blocks: qs}
 	benchQuery(b, q, labels.Selector{labels.NewMustRegexpMatcher("label-2", "value-.*0")}, true)
-}
-
-func BenchmarkPersistedQueries_3Blocks_Series_1M_RESelector_2_NoExpansion(b *testing.B) {
-	series := genSeries(3, 100)
-
-	block1, deferFunc, err := createBlock(series)
-	testutil.Ok(b, err)
-	defer deferFunc()
-
-	block2, deferFunc, err := createBlock(series)
-	testutil.Ok(b, err)
-	defer deferFunc()
-
-	block3, deferFunc, err := createBlock(series)
-	testutil.Ok(b, err)
-	defer deferFunc()
-
-	q1, err := NewBlockQuerier(block1, 0, 20)
-	testutil.Ok(b, err)
-	q2, err := NewBlockQuerier(block2, 0, 20)
-	testutil.Ok(b, err)
-	q3, err := NewBlockQuerier(block3, 0, 20)
-	testutil.Ok(b, err)
-
-	q := &querier{blocks: []Querier{q1, q2, q3}}
-
-	benchQuery(b, q, labels.Selector{
-		labels.NewMustRegexpMatcher("label-1", "value-.*0"),
-		labels.NewMustRegexpMatcher("label-2", "value-4.*"),
-	}, false)
 }
 
 func BenchmarkPersistedQueries_3Blocks_Series_1M_RESelector_2_Expansion(b *testing.B) {
 	series := genSeries(3, 100)
 
-	block1, deferFunc, err := createBlock(series)
-	testutil.Ok(b, err)
-	defer deferFunc()
+	qs := []Querier{}
 
-	block2, deferFunc, err := createBlock(series)
-	testutil.Ok(b, err)
-	defer deferFunc()
+	for i := 0; i < 3; i++ {
+		block, deferFunc, err := createBlock(series)
+		testutil.Ok(b, err)
+		defer deferFunc()
 
-	block3, deferFunc, err := createBlock(series)
-	testutil.Ok(b, err)
-	defer deferFunc()
+		q, err := NewBlockQuerier(block, 0, 20)
+		testutil.Ok(b, err)
 
-	q1, err := NewBlockQuerier(block1, 0, 20)
-	testutil.Ok(b, err)
-	q2, err := NewBlockQuerier(block2, 0, 20)
-	testutil.Ok(b, err)
-	q3, err := NewBlockQuerier(block3, 0, 20)
-	testutil.Ok(b, err)
+		qs = append(qs, q)
+	}
 
-	q := &querier{blocks: []Querier{q1, q2, q3}}
+	q := &querier{blocks: qs}
 
 	benchQuery(b, q, labels.Selector{
 		labels.NewMustRegexpMatcher("label-1", "value-.*0"),
@@ -583,60 +312,159 @@ func BenchmarkPersistedQueries_3Blocks_Series_1M_RESelector_2_Expansion(b *testi
 	}, true)
 }
 
-func BenchmarkPersistedQueries_3Blocks_Series_1M_RESelector_3_NoExpansion(b *testing.B) {
+func BenchmarkPersistedQueries_3Blocks_Series_1M_RESelector_3_Expansion(b *testing.B) {
 	series := genSeries(3, 100)
 
-	block1, deferFunc, err := createBlock(series)
-	testutil.Ok(b, err)
-	defer deferFunc()
+	qs := []Querier{}
 
-	block2, deferFunc, err := createBlock(series)
-	testutil.Ok(b, err)
-	defer deferFunc()
+	for i := 0; i < 3; i++ {
+		block, deferFunc, err := createBlock(series)
+		testutil.Ok(b, err)
+		defer deferFunc()
 
-	block3, deferFunc, err := createBlock(series)
-	testutil.Ok(b, err)
-	defer deferFunc()
+		q, err := NewBlockQuerier(block, 0, 20)
+		testutil.Ok(b, err)
 
-	q1, err := NewBlockQuerier(block1, 0, 20)
-	testutil.Ok(b, err)
-	q2, err := NewBlockQuerier(block2, 0, 20)
-	testutil.Ok(b, err)
-	q3, err := NewBlockQuerier(block3, 0, 20)
-	testutil.Ok(b, err)
+		qs = append(qs, q)
+	}
 
-	q := &querier{blocks: []Querier{q1, q2, q3}}
+	q := &querier{blocks: qs}
 
 	benchQuery(b, q, labels.Selector{
 		labels.NewMustRegexpMatcher("label-0", "value-5.*"),
 		labels.NewMustRegexpMatcher("label-1", "value-.*4"),
 		labels.NewMustRegexpMatcher("label-2", "value-.*4"),
-	}, false)
+	}, true)
 }
 
-func BenchmarkPersistedQueries_3Blocks_Series_1M_RESelector_3_Expansion(b *testing.B) {
+func BenchmarkPersistedQueries_10Blocks_Series_1M_EQSelector_1_Expansion(b *testing.B) {
+	series := genSeries(6, 10)
+
+	qs := []Querier{}
+
+	for i := 0; i < 10; i++ {
+		block, deferFunc, err := createBlock(series)
+		testutil.Ok(b, err)
+		defer deferFunc()
+
+		q, err := NewBlockQuerier(block, 0, 20)
+		testutil.Ok(b, err)
+
+		qs = append(qs, q)
+	}
+
+	q := &querier{blocks: qs}
+	benchQuery(b, q, labels.Selector{labels.NewEqualMatcher("label-1", "value-5")}, true)
+}
+
+func BenchmarkPersistedQueries_10Blocks_Series_1M_EQSelector_2_Expansion(b *testing.B) {
+	series := genSeries(6, 10)
+
+	qs := []Querier{}
+
+	for i := 0; i < 10; i++ {
+		block, deferFunc, err := createBlock(series)
+		testutil.Ok(b, err)
+		defer deferFunc()
+
+		q, err := NewBlockQuerier(block, 0, 20)
+		testutil.Ok(b, err)
+
+		qs = append(qs, q)
+	}
+
+	q := &querier{blocks: qs}
+	benchQuery(b, q, labels.Selector{
+		labels.NewEqualMatcher("label-1", "value-5"),
+		labels.NewEqualMatcher("label-2", "value-4"),
+	}, true)
+}
+
+func BenchmarkPersistedQueries_10Blocks_Series_1M_EQSelector_3_Expansion(b *testing.B) {
+	series := genSeries(6, 10)
+
+	qs := []Querier{}
+
+	for i := 0; i < 3; i++ {
+		block, deferFunc, err := createBlock(series)
+		testutil.Ok(b, err)
+		defer deferFunc()
+
+		q, err := NewBlockQuerier(block, 0, 20)
+		testutil.Ok(b, err)
+
+		qs = append(qs, q)
+	}
+
+	q := &querier{blocks: qs}
+	benchQuery(b, q, labels.Selector{
+		labels.NewEqualMatcher("label-1", "value-5"),
+		labels.NewEqualMatcher("label-2", "value-4"),
+		labels.NewEqualMatcher("label-3", "value-4"),
+	}, true)
+}
+
+func BenchmarkPersistedQueries_10Blocks_Series_1M_RESelector_1_Expansion(b *testing.B) {
 	series := genSeries(3, 100)
 
-	block1, deferFunc, err := createBlock(series)
-	testutil.Ok(b, err)
-	defer deferFunc()
+	qs := []Querier{}
 
-	block2, deferFunc, err := createBlock(series)
-	testutil.Ok(b, err)
-	defer deferFunc()
+	for i := 0; i < 3; i++ {
+		block, deferFunc, err := createBlock(series)
+		testutil.Ok(b, err)
+		defer deferFunc()
 
-	block3, deferFunc, err := createBlock(series)
-	testutil.Ok(b, err)
-	defer deferFunc()
+		q, err := NewBlockQuerier(block, 0, 20)
+		testutil.Ok(b, err)
 
-	q1, err := NewBlockQuerier(block1, 0, 20)
-	testutil.Ok(b, err)
-	q2, err := NewBlockQuerier(block2, 0, 20)
-	testutil.Ok(b, err)
-	q3, err := NewBlockQuerier(block3, 0, 20)
-	testutil.Ok(b, err)
+		qs = append(qs, q)
+	}
 
-	q := &querier{blocks: []Querier{q1, q2, q3}}
+	q := &querier{blocks: qs}
+	benchQuery(b, q, labels.Selector{labels.NewMustRegexpMatcher("label-2", "value-.*0")}, true)
+}
+
+func BenchmarkPersistedQueries_10Blocks_Series_1M_RESelector_2_Expansion(b *testing.B) {
+	series := genSeries(3, 100)
+
+	qs := []Querier{}
+
+	for i := 0; i < 3; i++ {
+		block, deferFunc, err := createBlock(series)
+		testutil.Ok(b, err)
+		defer deferFunc()
+
+		q, err := NewBlockQuerier(block, 0, 20)
+		testutil.Ok(b, err)
+
+		qs = append(qs, q)
+	}
+
+	q := &querier{blocks: qs}
+
+	benchQuery(b, q, labels.Selector{
+		labels.NewMustRegexpMatcher("label-1", "value-.*0"),
+		labels.NewMustRegexpMatcher("label-2", "value-4.*"),
+	}, true)
+}
+
+func BenchmarkPersistedQueries_10Blocks_Series_1M_RESelector_3_Expansion(b *testing.B) {
+	series := genSeries(3, 100)
+
+	qs := []Querier{}
+
+	for i := 0; i < 3; i++ {
+		block, deferFunc, err := createBlock(series)
+		testutil.Ok(b, err)
+		defer deferFunc()
+
+		q, err := NewBlockQuerier(block, 0, 20)
+		testutil.Ok(b, err)
+
+		qs = append(qs, q)
+	}
+
+	q := &querier{blocks: qs}
 
 	benchQuery(b, q, labels.Selector{
 		labels.NewMustRegexpMatcher("label-0", "value-5.*"),

--- a/bench_test.go
+++ b/bench_test.go
@@ -1,0 +1,240 @@
+package tsdb
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/prometheus/tsdb/labels"
+	"github.com/prometheus/tsdb/testutil"
+)
+
+func benchInMemQuery(b *testing.B, series []labels.Labels, selector labels.Selector, expand bool) {
+	hb, err := createHB(series)
+	testutil.Ok(b, err)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		q, err := NewBlockQuerier(hb, 0, 10)
+		testutil.Ok(b, err)
+
+		ss, err := q.Select(selector...)
+		testutil.Ok(b, err)
+		if expand {
+			for ss.Next() {
+				s := ss.At()
+				s.Labels()
+				s.Iterator()
+			}
+			testutil.Ok(b, ss.Err())
+		}
+
+		testutil.Ok(b, q.Close())
+	}
+}
+
+func benchPersistedQuery(b *testing.B, series []labels.Labels, selector labels.Selector, expand bool) {
+	hb, err := createHB(series)
+	testutil.Ok(b, err)
+
+	compactor, err := NewLeveledCompactor(nil, nil, []int64{1000000}, nil)
+	testutil.Ok(b, err)
+
+	tmpdir, err := ioutil.TempDir("", "test")
+	testutil.Ok(b, err)
+	defer os.RemoveAll(tmpdir)
+
+	ulid, err := compactor.Write(tmpdir, hb, hb.MinTime(), hb.MaxTime())
+	testutil.Ok(b, err)
+
+	block, err := OpenBlock(filepath.Join(tmpdir, ulid.String()), nil)
+	testutil.Ok(b, err)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		q, err := NewBlockQuerier(block, 0, 10)
+		testutil.Ok(b, err)
+
+		ss, err := q.Select(selector...)
+		testutil.Ok(b, err)
+		if expand {
+			for ss.Next() {
+				s := ss.At()
+				s.Labels()
+				s.Iterator()
+			}
+			testutil.Ok(b, ss.Err())
+		}
+
+		testutil.Ok(b, q.Close())
+	}
+}
+
+func createHB(
+	series []labels.Labels,
+) (*Head, error) {
+	hb, err := NewHead(nil, nil, NopWAL(), 10*60*60*1000)
+	if err != nil {
+		return nil, err
+	}
+
+	app := hb.Appender()
+	for _, l := range series {
+		if _, err := app.Add(l, 1, 0); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := app.Commit(); err != nil {
+		return nil, err
+	}
+
+	return hb, nil
+}
+
+func BenchmarkInMemQueries_Series_1M_EQSelector_1_NoExpansion(b *testing.B) {
+	series := genSeries(6, 10)
+
+	benchInMemQuery(b, series, labels.Selector{labels.NewEqualMatcher("label-1", "value-5")}, false)
+}
+
+func BenchmarkInMemQueries_Series_1M_EQSelector_1_Expansion(b *testing.B) {
+	series := genSeries(6, 10)
+
+	benchInMemQuery(b, series, labels.Selector{labels.NewEqualMatcher("label-1", "value-5")}, true)
+}
+
+func BenchmarkInMemQueries_Series_1M_EQSelector_2_NoExpansion(b *testing.B) {
+	series := genSeries(6, 10)
+
+	benchInMemQuery(b, series, labels.Selector{
+		labels.NewEqualMatcher("label-1", "value-5"),
+		labels.NewEqualMatcher("label-2", "value-4"),
+	}, false)
+}
+
+func BenchmarkInMemQueries_Series_1M_EQSelector_2_Expansion(b *testing.B) {
+	series := genSeries(6, 10)
+
+	benchInMemQuery(b, series, labels.Selector{
+		labels.NewEqualMatcher("label-1", "value-5"),
+		labels.NewEqualMatcher("label-2", "value-4"),
+	}, true)
+}
+
+func BenchmarkInMemQueries_Series_1M_EQSelector_3_NoExpansion(b *testing.B) {
+	series := genSeries(6, 10)
+
+	benchInMemQuery(b, series, labels.Selector{
+		labels.NewEqualMatcher("label-1", "value-5"),
+		labels.NewEqualMatcher("label-2", "value-4"),
+		labels.NewEqualMatcher("label-3", "value-4"),
+	}, false)
+}
+
+func BenchmarkInMemQueries_Series_1M_EQSelector_3_Expansion(b *testing.B) {
+	series := genSeries(6, 10)
+
+	benchInMemQuery(b, series, labels.Selector{
+		labels.NewEqualMatcher("label-1", "value-5"),
+		labels.NewEqualMatcher("label-2", "value-4"),
+		labels.NewEqualMatcher("label-3", "value-4"),
+	}, true)
+}
+
+func BenchmarkPersistedQueries_Series_1M_EQSelector_1_NoExpansion(b *testing.B) {
+	series := genSeries(6, 10)
+
+	benchPersistedQuery(b, series, labels.Selector{labels.NewEqualMatcher("label-1", "value-5")}, false)
+}
+
+func BenchmarkPersistedQueries_Series_1M_EQSelector_1_Expansion(b *testing.B) {
+	series := genSeries(6, 10)
+
+	benchPersistedQuery(b, series, labels.Selector{labels.NewEqualMatcher("label-1", "value-5")}, true)
+}
+
+func BenchmarkPersistedQueries_Series_1M_EQSelector_2_NoExpansion(b *testing.B) {
+	series := genSeries(6, 10)
+
+	benchPersistedQuery(b, series, labels.Selector{
+		labels.NewEqualMatcher("label-1", "value-5"),
+		labels.NewEqualMatcher("label-2", "value-4"),
+	}, false)
+}
+
+func BenchmarkPersistedQueries_Series_1M_EQSelector_2_Expansion(b *testing.B) {
+	series := genSeries(6, 10)
+
+	benchPersistedQuery(b, series, labels.Selector{
+		labels.NewEqualMatcher("label-1", "value-5"),
+		labels.NewEqualMatcher("label-2", "value-4"),
+	}, true)
+}
+
+func BenchmarkPersistedQueries_Series_1M_EQSelector_3_NoExpansion(b *testing.B) {
+	series := genSeries(6, 10)
+
+	benchPersistedQuery(b, series, labels.Selector{
+		labels.NewEqualMatcher("label-1", "value-5"),
+		labels.NewEqualMatcher("label-2", "value-4"),
+		labels.NewEqualMatcher("label-3", "value-4"),
+	}, false)
+}
+
+func BenchmarkPersistedQueries_Series_1M_EQSelector_3_Expansion(b *testing.B) {
+	series := genSeries(6, 10)
+
+	benchPersistedQuery(b, series, labels.Selector{
+		labels.NewEqualMatcher("label-1", "value-5"),
+		labels.NewEqualMatcher("label-2", "value-4"),
+		labels.NewEqualMatcher("label-3", "value-4"),
+	}, true)
+}
+
+// Meta helpers.
+func genSeries(numLabels, numVals int) []labels.Labels {
+	labelPrefix := "label-"
+	valuePrefix := "value-"
+
+	vals := make([]int, numLabels)
+	permuts := &([][]int{})
+
+	genSeriesRec(0, numLabels, numVals, vals, permuts)
+
+	series := make([]labels.Labels, 0)
+
+	for _, vals := range *permuts {
+		l := labels.Labels{}
+		for i, v := range vals {
+			l = append(l, labels.Label{
+				Name:  fmt.Sprintf("%s%d", labelPrefix, i),
+				Value: fmt.Sprintf("%s%d", valuePrefix, v),
+			})
+		}
+
+		series = append(series, l)
+	}
+
+	return series
+}
+
+func genSeriesRec(idx, numLabels, numVals int, vals []int, series *[][]int) {
+	if idx == numLabels {
+		vals2 := make([]int, len(vals))
+		copy(vals2, vals)
+		*series = append(*series, vals2)
+		return
+	}
+
+	for i := 0; i < numVals; i++ {
+		vals[idx] = i
+		genSeriesRec(idx+1, numLabels, numVals, vals, series)
+	}
+}

--- a/compact.go
+++ b/compact.go
@@ -126,6 +126,10 @@ func newCompactorMetrics(r prometheus.Registerer) *compactorMetrics {
 
 // NewLeveledCompactor returns a LeveledCompactor.
 func NewLeveledCompactor(r prometheus.Registerer, l log.Logger, ranges []int64, pool chunkenc.Pool) (*LeveledCompactor, error) {
+	if l == nil {
+		l = log.NewNopLogger()
+	}
+
 	if len(ranges) == 0 {
 		return nil, errors.Errorf("at least one range must be provided")
 	}


### PR DESCRIPTION
```
➜  tsdb git:(master) ✗ go test -run=XXX -bench=EQS 
goos: linux
goarch: amd64
pkg: github.com/prometheus/tsdb
BenchmarkInMemQueries_Series_1M_EQSelector_1_NoExpansion-8       	       5	 297650662 ns/op	 4653936 B/op	      34 allocs/op
BenchmarkInMemQueries_Series_1M_EQSelector_1_Expansion-8         	       3	 390691429 ns/op	76654000 B/op	 1000036 allocs/op
BenchmarkInMemQueries_Series_1M_EQSelector_2_NoExpansion-8       	     100	  19728340 ns/op	  386016 B/op	      27 allocs/op
BenchmarkInMemQueries_Series_1M_EQSelector_2_Expansion-8         	      50	  27937118 ns/op	 7586080 B/op	  100029 allocs/op
BenchmarkInMemQueries_Series_1M_EQSelector_3_NoExpansion-8       	    2000	   1089713 ns/op	   16240 B/op	      21 allocs/op
BenchmarkInMemQueries_Series_1M_EQSelector_3_Expansion-8         	    1000	   2383873 ns/op	  736304 B/op	   10023 allocs/op
BenchmarkPersistedQueries_Series_1M_EQSelector_1_NoExpansion-8   	  100000	     16793 ns/op	     560 B/op	       9 allocs/op
BenchmarkPersistedQueries_Series_1M_EQSelector_1_Expansion-8     	      10	 136797602 ns/op	92003316 B/op	 1300018 allocs/op
BenchmarkPersistedQueries_Series_1M_EQSelector_2_NoExpansion-8   	   50000	     31750 ns/op	     672 B/op	      12 allocs/op
BenchmarkPersistedQueries_Series_1M_EQSelector_2_Expansion-8     	     100	  15309107 ns/op	 9201015 B/op	  130014 allocs/op
BenchmarkPersistedQueries_Series_1M_EQSelector_3_NoExpansion-8   	   30000	     47446 ns/op	     816 B/op	      15 allocs/op
BenchmarkPersistedQueries_Series_1M_EQSelector_3_Expansion-8     	    1000	   1526049 ns/op	  920906 B/op	   13017 allocs/op
PASS
ok  	github.com/prometheus/tsdb	407.064s
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prometheus/tsdb/240)
<!-- Reviewable:end -->
