### PR TITLE
The cli tool can be built without local dependencies other than Docker

### DIFF
--- a/cmd/tsdb/.gitignore
+++ b/cmd/tsdb/.gitignore
@@ -1,3 +1,5 @@
 testdata*
 tsdb
 benchout
+dist/*
+!dist/.gitkeep

--- a/cmd/tsdb/Makefile
+++ b/cmd/tsdb/Makefile
@@ -9,3 +9,12 @@ bench: build
 	@go tool pprof --alloc_space -svg ./tsdb benchout/mem.prof > benchout/memprof.alloc.svg
 	@go tool pprof -svg ./tsdb benchout/block.prof > benchout/blockprof.svg
 	@go tool pprof -svg ./tsdb benchout/mutex.prof > benchout/mutexprof.svg
+
+distribute:
+	docker run \
+		--rm \
+		-i \
+		-v ${PWD}:/go/src/prom.local/tsdb \
+		-w /go/src/prom.local/tsdb \
+		golang:1.9 \
+		./compile.sh

--- a/cmd/tsdb/compile.sh
+++ b/cmd/tsdb/compile.sh
@@ -1,0 +1,4 @@
+#! /bin/sh
+go get github.com/mitchellh/gox 
+go get ./...
+gox -arch="amd64" -output="dist/{{.Dir}}_{{.OS}}_{{.Arch}}"


### PR DESCRIPTION
Fixes #242 .

Adds a `make` command to build the CLI tool for a few different architectures using the latest Go 1.9 image from Docker Hub.