### PR TITLE
fixed an issue in TestWALRestoreCorrupted

### DIFF
--- a/wal_test.go
+++ b/wal_test.go
@@ -371,9 +371,9 @@ func TestWALRestoreCorrupted(t *testing.T) {
 
 			testutil.Ok(t, w.cut())
 
-			//Sleep 2 seconds to avoid error where cut and test "cases" function may write or
-			//truncate the file out of orders as "cases" are not synchronized with cut.
-			//Hopefully cut will complete by 2 seconds
+			// Sleep 2 seconds to avoid error where cut and test "cases" function may write or
+			// truncate the file out of orders as "cases" are not synchronized with cut.
+			// Hopefully cut will complete by 2 seconds.
 			time.Sleep(2 * time.Second)
 
 			testutil.Ok(t, w.LogSamples([]RefSample{{T: 3, V: 4}}))

--- a/wal_test.go
+++ b/wal_test.go
@@ -19,6 +19,7 @@ import (
 	"math/rand"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/go-kit/kit/log"
 	"github.com/prometheus/tsdb/fileutil"
@@ -369,6 +370,11 @@ func TestWALRestoreCorrupted(t *testing.T) {
 			testutil.Ok(t, w.LogSamples([]RefSample{{T: 2, V: 3}}))
 
 			testutil.Ok(t, w.cut())
+
+			//Sleep 2 seconds to avoid error where cut and test "cases" function may write or
+			//truncate the file out of orders as "cases" are not synchronized with cut.
+			//Hopefully cut will complete by 2 seconds
+			time.Sleep(2 * time.Second)
 
 			testutil.Ok(t, w.LogSamples([]RefSample{{T: 3, V: 4}}))
 			testutil.Ok(t, w.LogSamples([]RefSample{{T: 5, V: 6}}))


### PR DESCRIPTION
Fixed a small issue with test case "TestWALRestoreCorrupted" as the test routine and cut method may update the same segment file concurrently and resulting in error sometime.