### PR TITLE
Fatal error handling (when writes to wal file fail)

### DIFF
--- a/compact.go
+++ b/compact.go
@@ -391,10 +391,19 @@ func (c *LeveledCompactor) write(dest string, meta *BlockMeta, blocks ...BlockRe
 
 	defer func(t time.Time) {
 		if err != nil {
-			c.metrics.failed.Inc()
+			if err.Error() == "No samples for this block" {
+				// Not an error actually
+				err = nil
+			} else {
+				c.metrics.failed.Inc()
+			}
+			_, err2 := os.Stat(tmp)
+			if os.IsNotExist(err2) {
+				return
+			}
 			// TODO(gouthamve): Handle error how?
-			if err := os.RemoveAll(tmp); err != nil {
-				level.Error(c.logger).Log("msg", "removed tmp folder after failed compaction", "err", err.Error())
+			if err2 = os.RemoveAll(tmp); err2 != nil {
+				level.Error(c.logger).Log("msg", "removed tmp folder after failed compaction", "err", err2.Error())
 			}
 		}
 		c.metrics.ran.Inc()
@@ -445,6 +454,12 @@ func (c *LeveledCompactor) write(dest string, meta *BlockMeta, blocks ...BlockRe
 	}
 	if err = indexw.Close(); err != nil {
 		return errors.Wrap(err, "close index writer")
+	}
+
+	if meta.Stats.NumSamples == 0 {
+		// No need for this directory
+		err = errors.New("No samples for this block")
+		return
 	}
 
 	// Create an empty tombstones file.

--- a/db.go
+++ b/db.go
@@ -187,6 +187,7 @@ func Open(dir string, l log.Logger, r prometheus.Registerer, opts *Options) (db 
 		compactionsEnabled: true,
 		chunkPool:          chunkenc.NewPool(),
 	}
+	errh.add(db)
 	db.metrics = newDBMetrics(db, r)
 
 	if !opts.NoLockfile {
@@ -224,6 +225,7 @@ func Open(dir string, l log.Logger, r prometheus.Registerer, opts *Options) (db 
 		return nil, errors.Wrap(err, "read WAL")
 	}
 
+	getErrorHandler().add(db)
 	go db.run()
 
 	return db, nil
@@ -583,6 +585,11 @@ func (db *DB) Close() error {
 	}
 	merr.Add(db.head.Close())
 	return merr.Err()
+}
+
+func (db *DB) handleError(err error) {
+	db.Close()
+	getErrorHandler().errorHandled()
 }
 
 // DisableCompactions disables compactions.

--- a/fatal_error_handler.go
+++ b/fatal_error_handler.go
@@ -1,0 +1,71 @@
+package tsdb
+
+import (
+	"container/list"
+	"os"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+type errHandler interface {
+	handleError(err error)
+}
+
+type errorHandler struct {
+	mtx         *sync.Mutex
+	wgr         *sync.WaitGroup
+	handlers    *list.List
+	fatal_error int32
+}
+
+var (
+	once sync.Once
+	errh *errorHandler
+)
+
+func getErrorHandler() *errorHandler {
+	once.Do(func() {
+		errh = &errorHandler{mtx: &sync.Mutex{}, wgr: &sync.WaitGroup{}, handlers: list.New()}
+	})
+	return errh
+}
+
+func (erh *errorHandler) add(handler errHandler) {
+	erh.mtx.Lock()
+	defer erh.mtx.Unlock()
+	for e := erh.handlers.Front(); e != nil; e = e.Next() {
+		if e.Value == handler {
+			return
+		}
+	}
+	erh.handlers.PushBack(handler)
+}
+
+func (erh *errorHandler) errorHandled() {
+	erh.wgr.Done()
+}
+
+func (erh *errorHandler) handleError(err error) {
+	if atomic.AddInt32(&errh.fatal_error, 1) != 1 {
+		return
+	}
+	go func() {
+		go func() {
+			time.Sleep(15 * time.Second)
+			erh.wgr.Add(-erh.handlers.Len())
+		}()
+		for e := erh.handlers.Front(); e != nil; e = e.Next() {
+			erh.wgr.Add(1)
+			go func(eh errHandler) {
+				eh.handleError(err)
+			}(e.Value.(errHandler))
+		}
+		erh.wgr.Wait()
+		os.Exit(1)
+	}()
+}
+
+func (erh *errorHandler) getFatalErrorCount() int32 {
+	return atomic.LoadInt32(&erh.fatal_error)
+}

--- a/init.go
+++ b/init.go
@@ -1,0 +1,28 @@
+// Copyright 2017 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tsdb
+
+import (
+	"hash/crc32"
+)
+
+// The table gets initialized with sync.Once but may still cause a race
+// with any other use of the crc32 package anywhere. Thus we initialize it
+// before.
+var castagnoliTable *crc32.Table
+
+func init() {
+	castagnoliTable = crc32.MakeTable(crc32.Castagnoli)
+	getErrorHandler()
+}

--- a/wal.go
+++ b/wal.go
@@ -845,7 +845,7 @@ func (w *SegmentWAL) safeWrite(buf []byte) error {
 		}
 	}
 	if n != len(buf) {
-		if err != nil {
+		if err == nil {
 			err = errors.New("Partial write")
 		} else {
 			err = errors.Wrap(err, "Partial write")

--- a/wal.go
+++ b/wal.go
@@ -44,6 +44,18 @@ const (
 
 	// WALFormatDefault is the version flag for the default outer segment file format.
 	WALFormatDefault = byte(1)
+
+	// count of bytes needed hold flag byte, type byte, length of buffer, and crc32 hash
+	// = 1 + 1 + 4 + 4 = 10
+	INFOByteCount = 10
+)
+
+var (
+	//HEADBytes to hold flag, type and length of a series of samples buffer
+	HEADBytes = []byte{0, 0, 0, 0, 0, 0}
+
+	//CRCBytes to hold the crc value for a series or samples
+	CRCBytes = []byte{0, 0, 0, 0}
 )
 
 // Entry types in a segment file.
@@ -86,6 +98,7 @@ type WAL interface {
 	Reader() WALReader
 	LogSeries([]RefSeries) error
 	LogSamples([]RefSample) error
+	LogSeriesAndSamples([]RefSeries, []RefSample) error
 	LogDeletes([]Stone) error
 	Truncate(mint int64, keep func(uint64) bool) error
 	Close() error
@@ -105,12 +118,13 @@ func (nopWAL) Read(
 ) error {
 	return nil
 }
-func (w nopWAL) Reader() WALReader                     { return w }
-func (nopWAL) LogSeries([]RefSeries) error             { return nil }
-func (nopWAL) LogSamples([]RefSample) error            { return nil }
-func (nopWAL) LogDeletes([]Stone) error                { return nil }
-func (nopWAL) Truncate(int64, func(uint64) bool) error { return nil }
-func (nopWAL) Close() error                            { return nil }
+func (w nopWAL) Reader() WALReader                                { return w }
+func (nopWAL) LogSeries([]RefSeries) error                        { return nil }
+func (nopWAL) LogSamples([]RefSample) error                       { return nil }
+func (nopWAL) LogSeriesAndSamples([]RefSeries, []RefSample) error { return nil }
+func (nopWAL) LogDeletes([]Stone) error                           { return nil }
+func (nopWAL) Truncate(int64, func(uint64) bool) error            { return nil }
+func (nopWAL) Close() error                                       { return nil }
 
 // WALReader reads entries from a WAL.
 type WALReader interface {
@@ -141,30 +155,25 @@ type RefSample struct {
 // the truncation threshold can be compacted.
 type segmentFile struct {
 	*os.File
-	maxTime   int64  // highest tombstone or sample timpstamp in segment
-	minSeries uint64 // lowerst series ID in segment
+	maxTime    int64   // highest tombstone or sample timpstamp in segment
+	minSeries  uint64  // lowerst series ID in segment
+	truncateAt []int64 // in case of write failures, where can be safely truncated
 }
 
 func newSegmentFile(f *os.File) *segmentFile {
-	return &segmentFile{
-		File:      f,
-		maxTime:   math.MinInt64,
-		minSeries: math.MaxUint64,
+	ret := &segmentFile{
+		File:       f,
+		maxTime:    math.MinInt64,
+		minSeries:  math.MaxUint64,
+		truncateAt: make([]int64, 0, 1024),
 	}
+	ret.truncateAt = append(ret.truncateAt, 0)
+	return ret
 }
 
 const (
 	walSegmentSizeBytes = 256 * 1024 * 1024 // 256 MB
 )
-
-// The table gets initialized with sync.Once but may still cause a race
-// with any other use of the crc32 package anywhere. Thus we initialize it
-// before.
-var castagnoliTable *crc32.Table
-
-func init() {
-	castagnoliTable = crc32.MakeTable(crc32.Castagnoli)
-}
 
 // newCRC32 initializes a CRC32 hash with a preconfigured polynomial, so the
 // polynomial may be easily changed in one location at a later time, if necessary.
@@ -240,7 +249,7 @@ func OpenSegmentWAL(dir string, logger log.Logger, flushInterval time.Duration, 
 		}
 		break
 	}
-
+	getErrorHandler().add(w)
 	go w.run(flushInterval)
 
 	return w, nil
@@ -380,7 +389,9 @@ func (w *SegmentWAL) Truncate(mint int64, keep func(uint64) bool) error {
 		}
 
 		buf := w.getBuffer()
+		buf.putBytes(HEADBytes)
 		flag = w.encodeSeries(buf, activeSeries)
+		buf.putBytes(CRCBytes)
 
 		_, err = w.writeTo(csf, crc32, WALEntrySeries, flag, buf.get())
 		w.putBuffer(buf)
@@ -438,7 +449,9 @@ func (w *SegmentWAL) Truncate(mint int64, keep func(uint64) bool) error {
 func (w *SegmentWAL) LogSeries(series []RefSeries) error {
 	buf := w.getBuffer()
 
+	buf.putBytes(HEADBytes)
 	flag := w.encodeSeries(buf, series)
+	buf.putBytes(CRCBytes)
 
 	w.mtx.Lock()
 	defer w.mtx.Unlock()
@@ -464,12 +477,11 @@ func (w *SegmentWAL) LogSeries(series []RefSeries) error {
 // LogSamples writes a batch of new samples to the log.
 func (w *SegmentWAL) LogSamples(samples []RefSample) error {
 	buf := w.getBuffer()
-
+	buf.putBytes(HEADBytes)
 	flag := w.encodeSamples(buf, samples)
-
+	buf.putBytes(CRCBytes)
 	w.mtx.Lock()
 	defer w.mtx.Unlock()
-
 	err := w.write(WALEntrySamples, flag, buf.get())
 
 	w.putBuffer(buf)
@@ -479,19 +491,71 @@ func (w *SegmentWAL) LogSamples(samples []RefSample) error {
 	}
 	tf := w.head()
 
-	for _, s := range samples {
-		if tf.maxTime < s.T {
-			tf.maxTime = s.T
+	//samples are "sorted" by timestamp already
+	if len(samples) > 0 && tf.maxTime < samples[len(samples)-1].T {
+		tf.maxTime = samples[len(samples)-1].T
+	}
+
+	return nil
+}
+
+// LogSeriesAndSamples writes a batch of new series labels and samples to the log.
+// All the data for series will be written or none from them
+// In case of write error, panic as otherwise corruption may happen and subsequent
+// write may also fail
+
+func (w *SegmentWAL) LogSeriesAndSamples(series []RefSeries, samples []RefSample) error {
+	buf := w.getBuffer()
+
+	// 6 bytes to hold type, flag and buf len
+	buf.putBytes([]byte{byte(WALEntrySeries), walSeriesSimple, 0, 0, 0, 0})
+	w.encodeSeries(buf, series)
+	binary.BigEndian.PutUint32(buf.get()[2:], uint32(buf.len()-6))
+	w.mtx.Lock()
+	w.crc32.Reset()
+	w.crc32.Write(buf.get())
+	chksum := w.crc32.Sum([]byte{})
+	w.mtx.Unlock()
+	buf.putBytes(chksum)
+
+	samples_start := buf.len()
+	buf.putBytes([]byte{byte(WALEntrySamples), walSamplesSimple, 0, 0, 0, 0})
+	w.encodeSamples(buf, samples)
+	binary.BigEndian.PutUint32(buf.get()[samples_start+2:], uint32(buf.len()-samples_start-6))
+	w.mtx.Lock()
+	w.crc32.Reset()
+	w.crc32.Write(buf.get()[samples_start:])
+	chksum = w.crc32.Sum([]byte{})
+	w.mtx.Unlock()
+	buf.putBytes(chksum)
+
+	w.mtx.Lock()
+	defer w.mtx.Unlock()
+
+	err := w.rawWrite(buf.get())
+	w.putBuffer(buf)
+	tf := w.head()
+	if err == nil {
+		for _, s := range series {
+			if tf.minSeries > s.Ref {
+				tf.minSeries = s.Ref
+			}
+		}
+
+		//samples are "sorted" by timestamp already
+		if len(samples) > 0 && tf.maxTime < samples[len(samples)-1].T {
+			tf.maxTime = samples[len(samples)-1].T
 		}
 	}
-	return nil
+	return err
 }
 
 // LogDeletes write a batch of new deletes to the log.
 func (w *SegmentWAL) LogDeletes(stones []Stone) error {
 	buf := w.getBuffer()
-
+	buf.putBytes(HEADBytes)
 	flag := w.encodeDeletes(buf, stones)
+	buf.putBytes(CRCBytes)
 
 	w.mtx.Lock()
 	defer w.mtx.Unlock()
@@ -693,6 +757,11 @@ func (w *SegmentWAL) run(interval time.Duration) {
 	for {
 		// Processing all enqueued operations has precedence over shutdown and
 		// background syncs.
+
+		if getErrorHandler().getFatalErrorCount() > 0 {
+			return
+		}
+
 		select {
 		case f := <-w.actorc:
 			if err := f(); err != nil {
@@ -736,6 +805,11 @@ func (w *SegmentWAL) Close() error {
 	return w.dirFile.Close()
 }
 
+func (w *SegmentWAL) handleError(err error) {
+	w.Close()
+	getErrorHandler().errorHandled()
+}
+
 const (
 	minSectorSize = 512
 
@@ -745,7 +819,63 @@ const (
 	walPageBytes = 16 * minSectorSize
 )
 
+// safeWrite looks for any write failure and calls fatal error handler in case of failures
+// as these errors are not recoverable
+func (w *SegmentWAL) safeWrite(buf []byte) error {
+	curFile := len(w.files) - 1
+	n, err := w.cur.Write(buf)
+	curPos, _ := w.files[curFile].Seek(0, os.SEEK_CUR)
+	if err == nil && n == len(buf) {
+		w.curN += int64(n)
+		w.files[curFile].truncateAt = append(w.files[curFile].truncateAt, w.curN)
+		y := sort.Search(len(w.files[curFile].truncateAt), func(l int) bool {
+			return w.files[curFile].truncateAt[l] > curPos
+		})
+		if y > 0 {
+			w.files[curFile].truncateAt = w.files[curFile].truncateAt[y-1:]
+		}
+	} else {
+		// write Failed, may be disk space issue, cannot recover, truncate the file at last safe
+		// position
+		y := sort.Search(len(w.files[curFile].truncateAt), func(l int) bool {
+			return w.files[curFile].truncateAt[l] > curPos
+		})
+		if y > 0 {
+			w.files[curFile].Truncate(w.files[curFile].truncateAt[y-1])
+		}
+	}
+	if n != len(buf) {
+		if err != nil {
+			err = errors.New("Partial write")
+		} else {
+			err = errors.Wrap(err, "Partial write")
+		}
+		getErrorHandler().handleError(err)
+	}
+	return err
+}
+
+func (w *SegmentWAL) rawWrite(buf []byte) error {
+	sz := int64(len(buf))
+	if getErrorHandler().getFatalErrorCount() > 0 {
+		return errors.New("Fatal error was detcted before")
+	}
+
+	newsz := w.curN + sz
+	if w.cur == nil || w.curN > w.segmentSize || newsz > w.segmentSize && sz <= w.segmentSize {
+		if err := w.cut(); err != nil {
+			// cannot recover from such error, better to exit
+			getErrorHandler().handleError(errors.Wrap(err, "wal file create problem"))
+			return err
+		}
+	}
+	return w.safeWrite(buf)
+}
+
 func (w *SegmentWAL) write(t WALEntryType, flag uint8, buf []byte) error {
+	if getErrorHandler().getFatalErrorCount() > 0 {
+		return errors.New("Fatal error was detcted before")
+	}
 	// Cut to the next segment if the entry exceeds the file size unless it would also
 	// exceed the size of a new segment.
 	// TODO(gouthamve): Add a test for this case where the commit is greater than segmentSize.
@@ -760,37 +890,42 @@ func (w *SegmentWAL) write(t WALEntryType, flag uint8, buf []byte) error {
 			return err
 		}
 	}
-	n, err := w.writeTo(w.cur, w.crc32, t, flag, buf)
 
-	w.curN += int64(n)
+	return w.safeWriteTo(w.crc32, t, flag, buf)
+}
 
-	return err
+func (w *SegmentWAL) updateExtraInfo(crc32 hash.Hash, t WALEntryType, flag uint8, buf []byte) error {
+	if len(buf) < INFOByteCount {
+		return errors.New("Insufficient data")
+	}
+	crc32.Reset()
+	buf[0] = byte(t)
+	buf[1] = flag
+
+	binary.BigEndian.PutUint32(buf[2:], uint32(len(buf))-INFOByteCount)
+	crc32.Write(buf[:len(buf)-4])
+	sums := crc32.Sum([]byte{})
+	copy(buf[len(buf)-4:], sums)
+
+	return nil
 }
 
 func (w *SegmentWAL) writeTo(wr io.Writer, crc32 hash.Hash, t WALEntryType, flag uint8, buf []byte) (int, error) {
-	if len(buf) == 0 {
+	err := w.updateExtraInfo(crc32, t, flag, buf)
+	if err != nil {
+		// just return
 		return 0, nil
 	}
-	crc32.Reset()
-	wr = io.MultiWriter(crc32, wr)
+	return wr.Write(buf)
+}
 
-	var b [6]byte
-	b[0] = byte(t)
-	b[1] = flag
-
-	binary.BigEndian.PutUint32(b[2:], uint32(len(buf)))
-
-	n1, err := wr.Write(b[:])
+func (w *SegmentWAL) safeWriteTo(crc32 hash.Hash, t WALEntryType, flag uint8, buf []byte) error {
+	err := w.updateExtraInfo(crc32, t, flag, buf)
 	if err != nil {
-		return n1, err
+		// just return
+		return nil
 	}
-	n2, err := wr.Write(buf)
-	if err != nil {
-		return n1 + n2, err
-	}
-	n3, err := wr.Write(crc32.Sum(b[:0]))
-
-	return n1 + n2 + n3, err
+	return w.safeWrite(buf)
 }
 
 const (

--- a/wal_test.go
+++ b/wal_test.go
@@ -35,14 +35,20 @@ func TestSegmentWAL_cut(t *testing.T) {
 	w, err := OpenSegmentWAL(tmpdir, nil, 0, nil)
 	testutil.Ok(t, err)
 
-	testutil.Ok(t, w.write(WALEntrySeries, 1, []byte("Hello World!!")))
+	buf := []byte{0, 0, 0, 0, 0, 0}
+	buf = append(buf, []byte("Hello World!!")...)
+	buf = append(buf, []byte{0, 0, 0, 0}...)
+	testutil.Ok(t, w.write(WALEntrySeries, 1, buf))
 
 	testutil.Ok(t, w.cut())
 
 	// Cutting creates a new file.
 	testutil.Equals(t, 2, len(w.files))
 
-	testutil.Ok(t, w.write(WALEntrySeries, 1, []byte("Hello World!!")))
+	buf = []byte{0, 0, 0, 0, 0, 0}
+	buf = append(buf, []byte("Hello World!!")...)
+	buf = append(buf, []byte{0, 0, 0, 0}...)
+	testutil.Ok(t, w.write(WALEntrySeries, 1, buf))
 
 	testutil.Ok(t, w.Close())
 

--- a/wal_test.go
+++ b/wal_test.go
@@ -19,6 +19,7 @@ import (
 	"math/rand"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/go-kit/kit/log"
 	"github.com/prometheus/tsdb/fileutil"
@@ -375,6 +376,11 @@ func TestWALRestoreCorrupted(t *testing.T) {
 			testutil.Ok(t, w.LogSamples([]RefSample{{T: 2, V: 3}}))
 
 			testutil.Ok(t, w.cut())
+
+			//Sleep 2 seconds to avoid error where cut and test "cases" may write or truncate
+			//the file out of orders as "cases" are not synchronized with cut.
+			//Hopefully cut will complete by 2 seconds
+			time.Sleep(2 * time.Second)
 
 			testutil.Ok(t, w.LogSamples([]RefSample{{T: 3, V: 4}}))
 			testutil.Ok(t, w.LogSamples([]RefSample{{T: 5, V: 6}}))


### PR DESCRIPTION
Added fatal error handling when writes to WAL file fails, mainly due to disk space problem. In such cases, the file is truncated to last safe position. This error is most likely unrecoverable. Also, during commit, series and samples are written together and either all of them will be added to WAL or none at all. Fatal error handler makes the process to exit (after max 15 seconds wait for any cleanup) in case of fatal error.

fixes https://github.com/prometheus/tsdb/issues/317
fixes https://github.com/prometheus/prometheus/issues/3283