### PR TITLE
Reduce index file size caused by symbol references by using indicies rather than offsets

### DIFF
--- a/docs/format/index.md
+++ b/docs/format/index.md
@@ -43,7 +43,7 @@ Most of the sections described below start with a `len` field. It always specifi
 The symbol table holds a sorted list of deduplicated strings that occurred in label pairs of the stored series. They can be referenced from subsequent sections and significantly reduce the total index size.
 
 The section contains a sequence of the string entries, each prefixed with the string's length in raw bytes. All strings are utf-8 encoded.
-Strings are referenced by pointing to the beginning of their length field. The strings are sorted in lexicographically ascending order.
+Strings are referenced by sequential indexing. The strings are sorted in lexicographically ascending order.
 
 ```
 ┌────────────────────┬─────────────────────┐

--- a/index/index.go
+++ b/index/index.go
@@ -343,10 +343,7 @@ func (w *Writer) AddSymbols(sym map[string]struct{}) error {
 	w.symbols = make(map[string]uint32, len(symbols))
 
 	for index, s := range symbols {
-		w.symbols[s] = uint32(w.pos) + headerSize + uint32(w.buf2.len())
-		if w.Version == 2 {
-			w.symbols[s] = uint32(index)
-		}
+		w.symbols[s] = uint32(index)
 		w.buf2.putUvarintStr(s)
 	}
 


### PR DESCRIPTION
fixes #249 

Left comments in sections where depending on whether we're using v1 or v2 all that would change is the var name (`offset` vs `index`) but not any of the functionality. 

Wasn't entirely sure if we want to change this struct: 
```
type hashEntry struct {
	keys   []string
	offset uint64
}
```

cc: @Gouthamve @fabxc 