### PR TITLE
Functions to get MinTime of DB and Block.

### DIFF
--- a/block.go
+++ b/block.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 
 	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
@@ -336,6 +337,11 @@ func (pb *Block) Tombstones() (TombstoneReader, error) {
 		return nil, err
 	}
 	return blockTombstoneReader{TombstoneReader: pb.tombstones, b: pb}, nil
+}
+
+// MinTime returns the lowest time bound from the meta of the block.
+func (pb *Block) MinTime() int64 {
+	return atomic.LoadInt64(&pb.meta.MinTime)
 }
 
 func (pb *Block) setCompactionFailed() error {

--- a/db.go
+++ b/db.go
@@ -563,6 +563,17 @@ func (db *DB) Head() *Head {
 	return db.head
 }
 
+// MinTime returns the lowest time bound of the oldest block.
+func (db *DB) MinTime() int64 {
+	db.mtx.RLock();
+	defer db.mtx.RUnlock();
+	if len(db.blocks) > 0 {
+		return db.blocks[0].MinTime()
+	} else {
+		return db.head.MinTime()
+	}
+}
+
 // Close the partition.
 func (db *DB) Close() error {
 	close(db.stopc)


### PR DESCRIPTION
As proposed/asked in #prometheus IRC, 
![screenshot from 2018-02-07 11-43-02](https://user-images.githubusercontent.com/15064823/35907400-d1a5e486-0c13-11e8-8627-4b51095586b6.png)
I have added the function to get `MinTime` of the DB - MinTime of the oldest block.

This can be used in some endpoint.