### PR TITLE
Fix crash when a series has no block

### DIFF
--- a/block.go
+++ b/block.go
@@ -438,7 +438,7 @@ Outer:
 
 		for _, chk := range chks {
 			if intervalOverlap(mint, maxt, chk.MinTime, chk.MaxTime) {
-				// Delete only until the current vlaues and not beyond.
+				// Delete only until the current values and not beyond.
 				tmin, tmax := clampInterval(mint, maxt, chks[0].MinTime, chks[len(chks)-1].MaxTime)
 				stones[p.At()] = Intervals{{tmin, tmax}}
 				continue Outer


### PR DESCRIPTION
Fixes https://github.com/prometheus/prometheus/issues/3788.

@Gouthamve I'm not sure how this can happen in practice but from a formal standpoint, some safety checks are missing. There's some overlap with @codesome's work on #270.