### PR TITLE
don't bail for missing meta.js files

### DIFF
--- a/compact.go
+++ b/compact.go
@@ -157,7 +157,9 @@ func (c *LeveledCompactor) Plan(dir string) ([]string, error) {
 	for _, dir := range dirs {
 		meta, err := readMetaFile(dir)
 		if err != nil {
-			// No need to return an error as this will be deleted when reloading the db.
+			level.Debug(c.logger).Log("msg", "couldn't read a block meta file at planning", "err", err)
+			// We continue with the rest of the blocks.
+			// This one will be deleted when reloading the db.
 			continue
 		}
 		dms = append(dms, dirMeta{dir, meta})

--- a/db.go
+++ b/db.go
@@ -505,8 +505,15 @@ func (db *DB) reload(deleteable ...string) (err error) {
 	for _, dir := range dirs {
 		meta, err := readMetaFile(dir)
 		if err != nil {
-			deleteable = append(deleteable, dir)
-			level.Error(db.logger).Log("msg", "dir set for deletion due to error in the meta file", "dir", dir, "err", err.Error())
+			if os.IsNotExist(err) {
+				deleteable = append(deleteable, dir)
+				level.Error(db.logger).Log("msg", "dir set for deletion due to error in the meta file", "dir", dir, "err", err.Error())
+				continue
+			}
+			return errors.Wrapf(err, "read meta information %s", dir)
+		}
+
+		if stringsContain(deleteable, dir) {
 			continue
 		}
 

--- a/db.go
+++ b/db.go
@@ -319,7 +319,7 @@ func (db *DB) retentionCutoff() (b bool, err error) {
 	last := blocks[len(db.blocks)-1]
 
 	mint := last.Meta().MaxTime - int64(db.opts.RetentionDuration)
-	dirs, err := retentionCutoffDirs(db.dir, mint)
+	dirs, err := retentionCutoffDirs(db.logger, db.dir, mint)
 	if err != nil {
 		return false, err
 	}
@@ -433,7 +433,7 @@ func (db *DB) compact() (changes bool, err error) {
 
 // retentionCutoffDirs returns all directories of blocks in dir that are strictly
 // before mint.
-func retentionCutoffDirs(dir string, mint int64) ([]string, error) {
+func retentionCutoffDirs(l log.Logger, dir string, mint int64) ([]string, error) {
 	df, err := fileutil.OpenDir(dir)
 	if err != nil {
 		return nil, errors.Wrapf(err, "open directory")
@@ -450,7 +450,8 @@ func retentionCutoffDirs(dir string, mint int64) ([]string, error) {
 	for _, dir := range dirs {
 		meta, err := readMetaFile(dir)
 		if err != nil {
-			return nil, errors.Wrapf(err, "read block meta %s", dir)
+			delDirs = append(delDirs, dir)
+			continue
 		}
 		// The first block we encounter marks that we crossed the boundary
 		// of deletable blocks.
@@ -504,10 +505,8 @@ func (db *DB) reload(deleteable ...string) (err error) {
 	for _, dir := range dirs {
 		meta, err := readMetaFile(dir)
 		if err != nil {
-			return errors.Wrapf(err, "read meta information %s", dir)
-		}
-		// If the block is pending for deletion, don't add it to the new block set.
-		if stringsContain(deleteable, dir) {
+			deleteable = append(deleteable, dir)
+			level.Error(db.logger).Log("msg", "dir set for deletion due to error in the meta file", "dir", dir, "err", err.Error())
 			continue
 		}
 
@@ -541,8 +540,14 @@ func (db *DB) reload(deleteable ...string) (err error) {
 		if err := b.Close(); err != nil {
 			level.Warn(db.logger).Log("msg", "closing block failed", "err", err)
 		}
-		if err := os.RemoveAll(b.Dir()); err != nil {
-			level.Warn(db.logger).Log("msg", "deleting block failed", "err", err)
+		deleteable = append(deleteable, b.Dir())
+	}
+
+	for _, d := range deleteable {
+		if _, err := os.Stat(d); err == nil {
+			if err := os.RemoveAll(d); err != nil {
+				level.Warn(db.logger).Log("msg", "deleting block failed", "err", err)
+			}
 		}
 	}
 

--- a/db_test.go
+++ b/db_test.go
@@ -812,16 +812,13 @@ func TestDB_Retention(t *testing.T) {
 // TestDBMissingMeta assures that the db can be opened even when a folder is missing the meta file.
 // Also ensures that the folder with the missing meta is deleted when reloading the db.
 func TestDBMissingMeta(t *testing.T) {
-	tmpdir, _ := ioutil.TempDir("", "test")
-	defer os.RemoveAll(tmpdir)
-
-	db, err := Open(tmpdir, nil, nil, nil)
-	testutil.Ok(t, err)
+	db, close := openTestDB(t, nil)
+	defer close()
 
 	lbls := labels.Labels{labels.Label{Name: "labelname", Value: "labelvalue"}}
 
 	app := db.Appender()
-	_, err = app.Add(lbls, 0, 1)
+	_, err := app.Add(lbls, 0, 1)
 	testutil.Ok(t, err)
 	testutil.Ok(t, app.Commit())
 
@@ -837,7 +834,7 @@ func TestDBMissingMeta(t *testing.T) {
 	testutil.Ok(t, filepath.Walk(snap, func(path string, f os.FileInfo, err error) error {
 		if f.Name() == metaFilename {
 			deleteable = filepath.Dir(path)
-			return nil
+			return os.Remove(path)
 		}
 		return nil
 	}))

--- a/repair.go
+++ b/repair.go
@@ -30,6 +30,10 @@ func repairBadIndexVersion(logger log.Logger, dir string) error {
 			continue
 		}
 		d = path.Join(dir, d)
+		// Skip dirs with missing meta. These will be deleted when reloading the db.
+		if _, err := os.Stat(filepath.Join(dir, metaFilename)); os.IsNotExist(err) {
+			continue
+		}
 
 		meta, err := readBogusMetaFile(d)
 		if err != nil {

--- a/repair.go
+++ b/repair.go
@@ -31,7 +31,7 @@ func repairBadIndexVersion(logger log.Logger, dir string) error {
 		}
 		d = path.Join(dir, d)
 		// Skip dirs with missing meta. These will be deleted when reloading the db.
-		if _, err := os.Stat(filepath.Join(dir, metaFilename)); os.IsNotExist(err) {
+		if _, err := os.Stat(filepath.Join(d, metaFilename)); os.IsNotExist(err) {
 			continue
 		}
 

--- a/repair.go
+++ b/repair.go
@@ -30,8 +30,10 @@ func repairBadIndexVersion(logger log.Logger, dir string) error {
 			continue
 		}
 		d = path.Join(dir, d)
-		// Skip dirs with missing meta. These will be deleted when reloading the db.
 		if _, err := os.Stat(filepath.Join(d, metaFilename)); os.IsNotExist(err) {
+			level.Debug(logger).Log("msg", "couldn't read a block meta file at index repair", "err", err)
+			// We continue with the rest of the blocks.
+			// This one will be deleted when reloading the db.
 			continue
 		}
 

--- a/repair_test.go
+++ b/repair_test.go
@@ -76,7 +76,7 @@ func TestRepairBadIndexVersion(t *testing.T) {
 	}
 
 	// On DB opening all blocks in the base dir should be repaired.
-	db, _ := Open("testdata/repair_index_version", nil, nil, nil)
+	db, err := Open("testdata/repair_index_version", nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
this change ensures that the db can be opened even when one or more folders are missing the meta.js file.
These are skipped when opening the db and deleted when db.reload is called.