### PR TITLE
Tests cleanup tmps

### DIFF
--- a/block_test.go
+++ b/block_test.go
@@ -39,8 +39,9 @@ func TestBlockMetaMustNeverBeVersion2(t *testing.T) {
 }
 
 func TestSetCompactionFailed(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "test-tsdb")
+	tmpdir, err := ioutil.TempDir("", "test")
 	testutil.Ok(t, err)
+	defer os.RemoveAll(tmpdir)
 
 	b := createEmptyBlock(t, tmpdir)
 

--- a/compact_test.go
+++ b/compact_test.go
@@ -328,6 +328,7 @@ func TestCompactionFailWillCleanUpTempDir(t *testing.T) {
 
 	tmpdir, err := ioutil.TempDir("", "test")
 	testutil.Ok(t, err)
+	defer os.RemoveAll(tmpdir)
 
 	testutil.NotOk(t, compactor.write(tmpdir, &BlockMeta{}, erringBReader{}))
 	_, err = os.Stat(filepath.Join(tmpdir, BlockMeta{}.ULID.String()) + ".tmp")

--- a/wal_test.go
+++ b/wal_test.go
@@ -78,7 +78,7 @@ func TestSegmentWAL_Truncate(t *testing.T) {
 
 	dir, err := ioutil.TempDir("", "test_wal_log_truncate")
 	testutil.Ok(t, err)
-	// defer os.RemoveAll(dir)
+	defer os.RemoveAll(dir)
 
 	w, err := OpenSegmentWAL(dir, nil, 0, nil)
 	testutil.Ok(t, err)


### PR DESCRIPTION
some tests were leaving temporary dirs
also refactored few to use openTestDB()