### PR TITLE
implement atomic mutex and use it.

### DIFF
--- a/cmd/tsdb/main.go
+++ b/cmd/tsdb/main.go
@@ -29,6 +29,8 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"github.com/prometheus/tsdb/mutex"
+
 	"github.com/go-kit/kit/log"
 	"github.com/pkg/errors"
 	"github.com/prometheus/tsdb"
@@ -150,7 +152,7 @@ func (b *writeBenchmark) run() {
 const timeDelta = 30000
 
 func (b *writeBenchmark) ingestScrapes(lbls []labels.Labels, scrapeCount int) (uint64, error) {
-	var mu sync.Mutex
+	var mu mutex.Atomic
 	var total uint64
 
 	for i := 0; i < scrapeCount; i += 100 {

--- a/head.go
+++ b/head.go
@@ -30,6 +30,7 @@ import (
 	"github.com/prometheus/tsdb/chunks"
 	"github.com/prometheus/tsdb/index"
 	"github.com/prometheus/tsdb/labels"
+	"github.com/prometheus/tsdb/mutex"
 )
 
 var (
@@ -1090,8 +1091,7 @@ type sample struct {
 // memSeries is the in-memory representation of a series. None of its methods
 // are goroutine safe and it is the caller's responsibility to lock it.
 type memSeries struct {
-	sync.Mutex
-
+	mutex.Atomic
 	ref          uint64
 	lset         labels.Labels
 	chunks       []*memChunk

--- a/mutex/mutex.go
+++ b/mutex/mutex.go
@@ -1,0 +1,28 @@
+package mutex
+
+import (
+	"runtime"
+	"sync/atomic"
+)
+
+// Atomic is a mutual exclusion atomic lock.
+// The zero value for a Mutex is an unlocked mutex.
+//
+// A Mutex must not be copied after first use.
+type Atomic struct {
+	state uint32
+}
+
+// Lock locks m.
+// If the lock is already in use, the calling goroutine
+// blocks until the mutex is available.
+func (m *Atomic) Lock() {
+	for !atomic.CompareAndSwapUint32(&m.state, 0, 1) {
+		runtime.Gosched() //without this it locks up on GOMAXPROCS > 1
+	}
+}
+
+// Unlock unlocks m.
+func (m *Atomic) Unlock() {
+	atomic.StoreUint32(&m.state, 0)
+}

--- a/wal.go
+++ b/wal.go
@@ -27,6 +27,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/prometheus/tsdb/mutex"
+
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
@@ -174,7 +176,7 @@ func newCRC32() hash.Hash32 {
 
 // SegmentWAL is a write ahead log for series data.
 type SegmentWAL struct {
-	mtx     sync.Mutex
+	mtx     mutex.Atomic
 	metrics *walMetrics
 
 	dirFile *os.File


### PR DESCRIPTION
before
>> completed stage=ingestScrapes duration=10.715800978s
 > total samples: 60000000
 > samples/sec: 5.599203370354241e+06

after

>> completed stage=ingestScrapes duration=9.638972787s
 > total samples: 60000000
 > samples/sec: 6.224723718283271e+06

a simplified version of the sync.Mutex which can e used across other places that we would need locking.