### PR TITLE
Close file for windows platform

### DIFF
--- a/repair.go
+++ b/repair.go
@@ -61,6 +61,9 @@ func repairBadIndexVersion(logger log.Logger, dir string) error {
 		if err := repl.Close(); err != nil {
 			return err
 		}
+		if err := broken.Close(); err != nil {
+			return err
+		}
 		if err := renameFile(repl.Name(), broken.Name()); err != nil {
 			return err
 		}


### PR DESCRIPTION
Windows needs files that are being deleted to be closed.

Fixes: https://github.com/prometheus/prometheus/issues/3956

@fabxc @brian-brazil Should fix the mentioned issue, but we also need to enable tests on windows if we plan to catch bugs like these earlier.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prometheus/tsdb/300)
<!-- Reviewable:end -->
