### PR TITLE
repair + compact: Improved logging for easier future debug purposes.

### DIFF
--- a/repair.go
+++ b/repair.go
@@ -36,9 +36,20 @@ func repairBadIndexVersion(logger log.Logger, dir string) error {
 			return err
 		}
 		if meta.Version == 1 {
+			level.Info(logger).Log(
+				"msg", "found healthy block",
+				"mint", meta.MinTime,
+				"maxt", meta.MaxTime,
+				"ulid", meta.ULID,
+			)
 			continue
 		}
-		level.Info(logger).Log("msg", "fixing broken block", "ulid", meta.ULID)
+		level.Info(logger).Log(
+			"msg", "fixing broken block",
+			"mint", meta.MinTime,
+			"maxt", meta.MaxTime,
+			"ulid", meta.ULID,
+		)
 
 		repl, err := os.Create(filepath.Join(d, "index.repaired"))
 		if err != nil {


### PR DESCRIPTION
This is based on my experience while debugging https://github.com/prometheus/prometheus/issues/3943.

I needed to deduct few things, and all that would be just bit easier with these two logs:
- new block's ULID on each compaction.
- actual list of Blocks (ulid + time range) on Prometheus startup (easy to log that while repairing blocks).

We don't really need blocks that takes part in compaction - that can be deducted easily based on time ranges of blocks we have currently in system.

Additionally, fixed comments.

What do you think @fabxc  @Gouthamve ?

Signed-off-by: Bartek Plotka <bwplotka@gmail.com>