### PR TITLE
db: Fixed validateBlockSequence, exported it and added tests.

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -940,4 +940,29 @@ func TestOverlappingBlocksDetectsAllOverlaps(t *testing.T) {
 		{metas[6], o5}, {o5, metas[7]}, {o5, metas[8]},
 		{metas[9], o6a, o6b}, {o6a, metas[10]},
 	}, OverlappingBlocks(append(metas, o1, o2, o3a, o3b, o4, o5, o6a, o6b)))
+
+	// Additional cases.
+	a1 := BlockMeta{MinTime: 1, MaxTime: 5}
+	a2 := BlockMeta{MinTime: 1, MaxTime: 2}
+	a3 := BlockMeta{MinTime: 3, MaxTime: 4}
+	a4 := BlockMeta{MinTime: 3, MaxTime: 4}
+	testutil.Equals(t, [][]BlockMeta{{a1, a2}, {a1, a3, a4}}, OverlappingBlocks(append([]BlockMeta{a1}, a2, a3, a4)))
+
+	var nc1 []BlockMeta
+	nc1 = append(nc1, BlockMeta{MinTime: 1, MaxTime: 5})
+	nc1 = append(nc1, BlockMeta{MinTime: 2, MaxTime: 3})
+	nc1 = append(nc1, BlockMeta{MinTime: 2, MaxTime: 3})
+	nc1 = append(nc1, BlockMeta{MinTime: 2, MaxTime: 3})
+	nc1 = append(nc1, BlockMeta{MinTime: 2, MaxTime: 3})
+	nc1 = append(nc1, BlockMeta{MinTime: 2, MaxTime: 6})
+	nc1 = append(nc1, BlockMeta{MinTime: 3, MaxTime: 5})
+	nc1 = append(nc1, BlockMeta{MinTime: 5, MaxTime: 7})
+	nc1 = append(nc1, BlockMeta{MinTime: 7, MaxTime: 10})
+	nc1 = append(nc1, BlockMeta{MinTime: 8, MaxTime: 9})
+	testutil.Equals(t, [][]BlockMeta{
+		{nc1[0], nc1[1], nc1[2], nc1[3], nc1[4], nc1[5]}, // 1-5, 2-3, 2-3, 2-3, 2-3, 2,6
+		{nc1[0], nc1[5], nc1[6]}, // 1-5, 2-6, 3-5
+		{nc1[5], nc1[7]}, // 2-6, 5-7
+		{nc1[8], nc1[9]}, // 7-10, 8-9
+	}, OverlappingBlocks(nc1))
 }

--- a/db_test.go
+++ b/db_test.go
@@ -21,7 +21,6 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
 	"github.com/prometheus/tsdb/labels"
 	"github.com/prometheus/tsdb/testutil"
@@ -895,17 +894,11 @@ func expandSeriesSet(ss SeriesSet) ([]labels.Labels, error) {
 }
 
 func TestOverlappingBlocksDetectsAllOverlaps(t *testing.T) {
-	u := uint64(0)
-	newULID := func() ulid.ULID {
-		u++
-		return ulid.MustNew(u, nil)
-	}
-
 	// Create 10 blocks that does not overlap (0-10, 10-20, ..., 100-110) but in reverse order to ensure our algorithm
 	// will handle that.
 	var metas = make([]BlockMeta, 11)
 	for i := 10; i >= 0; i-- {
-		metas[i] = BlockMeta{MinTime: int64(i * 10), MaxTime: int64((i + 1) * 10), ULID: newULID()}
+		metas[i] = BlockMeta{MinTime: int64(i * 10), MaxTime: int64((i + 1) * 10)}
 	}
 
 	testutil.Assert(t, len(OverlappingBlocks(metas)) == 0, "we found unexpected overlaps")
@@ -913,28 +906,28 @@ func TestOverlappingBlocksDetectsAllOverlaps(t *testing.T) {
 	// Add overlapping blocks.
 
 	// o1 overlaps with 10-20.
-	o1 := BlockMeta{MinTime: 15, MaxTime: 17, ULID: newULID()}
+	o1 := BlockMeta{MinTime: 15, MaxTime: 17}
 	testutil.Equals(t, [][]BlockMeta{{metas[1], o1}}, OverlappingBlocks(append(metas, o1)))
 
 	// o2 overlaps with 20-30 and 30-40.
-	o2 := BlockMeta{MinTime: 21, MaxTime: 31, ULID: newULID()}
+	o2 := BlockMeta{MinTime: 21, MaxTime: 31}
 	testutil.Equals(t, [][]BlockMeta{{metas[2], o2}, {o2, metas[3]}}, OverlappingBlocks(append(metas, o2)))
 
 	// o3a and o3b overlaps with 30-40 and each other.
-	o3a := BlockMeta{MinTime: 33, MaxTime: 39, ULID: newULID()}
-	o3b := BlockMeta{MinTime: 34, MaxTime: 36, ULID: newULID()}
+	o3a := BlockMeta{MinTime: 33, MaxTime: 39}
+	o3b := BlockMeta{MinTime: 34, MaxTime: 36}
 	testutil.Equals(t, [][]BlockMeta{{metas[3], o3a, o3b}}, OverlappingBlocks(append(metas, o3a, o3b)))
 
 	// o4 is 1:1 overlap with 50-60.
-	o4 := BlockMeta{MinTime: 50, MaxTime: 60, ULID: newULID()}
+	o4 := BlockMeta{MinTime: 50, MaxTime: 60}
 	testutil.Equals(t, [][]BlockMeta{{metas[5], o4}}, OverlappingBlocks(append(metas, o4)))
 
 	// o5 overlaps with 60-70, 70-80 and 80-90.
-	o5 := BlockMeta{MinTime: 61, MaxTime: 85, ULID: newULID()}
+	o5 := BlockMeta{MinTime: 61, MaxTime: 85}
 	testutil.Equals(t, [][]BlockMeta{{metas[6], o5}, {o5, metas[7]}, {o5, metas[8]}}, OverlappingBlocks(append(metas, o5)))
 
 	// o6a overlaps with 90-100, 100-110 and o6b, o6b overlaps with 90-100 and o6a.
-	o6a := BlockMeta{MinTime: 92, MaxTime: 105, ULID: newULID()}
-	o6b := BlockMeta{MinTime: 94, MaxTime: 99, ULID: newULID()}
+	o6a := BlockMeta{MinTime: 92, MaxTime: 105}
+	o6b := BlockMeta{MinTime: 94, MaxTime: 99}
 	testutil.Equals(t, [][]BlockMeta{{metas[9], o6a, o6b}, {o6a, metas[10]}}, OverlappingBlocks(append(metas, o6a, o6b)))
 }

--- a/db_test.go
+++ b/db_test.go
@@ -907,13 +907,13 @@ func TestOverlappingBlocksDetectsAllOverlaps(t *testing.T) {
 
 	// o1 overlaps with 10-20.
 	o1 := BlockMeta{MinTime: 15, MaxTime: 17}
-	testutil.Equals(t, map[TimeRange][]BlockMeta{
+	testutil.Equals(t, Overlaps{
 		{Min: 15, Max: 17}: {metas[1], o1},
 	}, OverlappingBlocks(append(metas, o1)))
 
 	// o2 overlaps with 20-30 and 30-40.
 	o2 := BlockMeta{MinTime: 21, MaxTime: 31}
-	testutil.Equals(t, map[TimeRange][]BlockMeta{
+	testutil.Equals(t, Overlaps{
 		{Min: 21, Max: 30}: {metas[2], o2},
 		{Min: 30, Max: 31}: {o2, metas[3]},
 	}, OverlappingBlocks(append(metas, o2)))
@@ -921,19 +921,19 @@ func TestOverlappingBlocksDetectsAllOverlaps(t *testing.T) {
 	// o3a and o3b overlaps with 30-40 and each other.
 	o3a := BlockMeta{MinTime: 33, MaxTime: 39}
 	o3b := BlockMeta{MinTime: 34, MaxTime: 36}
-	testutil.Equals(t, map[TimeRange][]BlockMeta{
+	testutil.Equals(t, Overlaps{
 		{Min: 34, Max: 36}: {metas[3], o3a, o3b},
 	}, OverlappingBlocks(append(metas, o3a, o3b)))
 
 	// o4 is 1:1 overlap with 50-60.
 	o4 := BlockMeta{MinTime: 50, MaxTime: 60}
-	testutil.Equals(t, map[TimeRange][]BlockMeta{
+	testutil.Equals(t, Overlaps{
 		{Min: 50, Max: 60}: {metas[5], o4},
 	}, OverlappingBlocks(append(metas, o4)))
 
 	// o5 overlaps with 60-70, 70-80 and 80-90.
 	o5 := BlockMeta{MinTime: 61, MaxTime: 85}
-	testutil.Equals(t, map[TimeRange][]BlockMeta{
+	testutil.Equals(t, Overlaps{
 		{Min: 61, Max: 70}: {metas[6], o5},
 		{Min: 70, Max: 80}: {o5, metas[7]},
 		{Min: 80, Max: 85}: {o5, metas[8]},
@@ -942,13 +942,13 @@ func TestOverlappingBlocksDetectsAllOverlaps(t *testing.T) {
 	// o6a overlaps with 90-100, 100-110 and o6b, o6b overlaps with 90-100 and o6a.
 	o6a := BlockMeta{MinTime: 92, MaxTime: 105}
 	o6b := BlockMeta{MinTime: 94, MaxTime: 99}
-	testutil.Equals(t, map[TimeRange][]BlockMeta{
+	testutil.Equals(t, Overlaps{
 		{Min: 94, Max: 99}:   {metas[9], o6a, o6b},
 		{Min: 100, Max: 105}: {o6a, metas[10]},
 	}, OverlappingBlocks(append(metas, o6a, o6b)))
 
 	// All together.
-	testutil.Equals(t, map[TimeRange][]BlockMeta{
+	testutil.Equals(t, Overlaps{
 		{Min: 15, Max: 17}: {metas[1], o1},
 		{Min: 21, Max: 30}: {metas[2], o2}, {Min: 30, Max: 31}: {o2, metas[3]},
 		{Min: 34, Max: 36}: {metas[3], o3a, o3b},
@@ -969,7 +969,7 @@ func TestOverlappingBlocksDetectsAllOverlaps(t *testing.T) {
 	nc1 = append(nc1, BlockMeta{MinTime: 5, MaxTime: 7})
 	nc1 = append(nc1, BlockMeta{MinTime: 7, MaxTime: 10})
 	nc1 = append(nc1, BlockMeta{MinTime: 8, MaxTime: 9})
-	testutil.Equals(t, map[TimeRange][]BlockMeta{
+	testutil.Equals(t, Overlaps{
 		{Min: 2, Max: 3}: {nc1[0], nc1[1], nc1[2], nc1[3], nc1[4], nc1[5]}, // 1-5, 2-3, 2-3, 2-3, 2-3, 2,6
 		{Min: 3, Max: 5}: {nc1[0], nc1[5], nc1[6]},                         // 1-5, 2-6, 3-5
 		{Min: 5, Max: 6}: {nc1[5], nc1[7]},                                 // 2-6, 5-7

--- a/db_test.go
+++ b/db_test.go
@@ -907,47 +907,57 @@ func TestOverlappingBlocksDetectsAllOverlaps(t *testing.T) {
 
 	// o1 overlaps with 10-20.
 	o1 := BlockMeta{MinTime: 15, MaxTime: 17}
-	testutil.Equals(t, [][]BlockMeta{{metas[1], o1}}, OverlappingBlocks(append(metas, o1)))
+	testutil.Equals(t, map[TimeRange][]BlockMeta{
+		{Min: 15, Max: 17}: {metas[1], o1},
+	}, OverlappingBlocks(append(metas, o1)))
 
 	// o2 overlaps with 20-30 and 30-40.
 	o2 := BlockMeta{MinTime: 21, MaxTime: 31}
-	testutil.Equals(t, [][]BlockMeta{{metas[2], o2}, {o2, metas[3]}}, OverlappingBlocks(append(metas, o2)))
+	testutil.Equals(t, map[TimeRange][]BlockMeta{
+		{Min: 21, Max: 30}: {metas[2], o2},
+		{Min: 30, Max: 31}: {o2, metas[3]},
+	}, OverlappingBlocks(append(metas, o2)))
 
 	// o3a and o3b overlaps with 30-40 and each other.
 	o3a := BlockMeta{MinTime: 33, MaxTime: 39}
 	o3b := BlockMeta{MinTime: 34, MaxTime: 36}
-	testutil.Equals(t, [][]BlockMeta{{metas[3], o3a, o3b}}, OverlappingBlocks(append(metas, o3a, o3b)))
+	testutil.Equals(t, map[TimeRange][]BlockMeta{
+		{Min: 34, Max: 36}: {metas[3], o3a, o3b},
+	}, OverlappingBlocks(append(metas, o3a, o3b)))
 
 	// o4 is 1:1 overlap with 50-60.
 	o4 := BlockMeta{MinTime: 50, MaxTime: 60}
-	testutil.Equals(t, [][]BlockMeta{{metas[5], o4}}, OverlappingBlocks(append(metas, o4)))
+	testutil.Equals(t, map[TimeRange][]BlockMeta{
+		{Min: 50, Max: 60}: {metas[5], o4},
+	}, OverlappingBlocks(append(metas, o4)))
 
 	// o5 overlaps with 60-70, 70-80 and 80-90.
 	o5 := BlockMeta{MinTime: 61, MaxTime: 85}
-	testutil.Equals(t, [][]BlockMeta{{metas[6], o5}, {o5, metas[7]}, {o5, metas[8]}}, OverlappingBlocks(append(metas, o5)))
+	testutil.Equals(t, map[TimeRange][]BlockMeta{
+		{Min: 61, Max: 70}: {metas[6], o5},
+		{Min: 70, Max: 80}: {o5, metas[7]},
+		{Min: 80, Max: 85}: {o5, metas[8]},
+	}, OverlappingBlocks(append(metas, o5)))
 
 	// o6a overlaps with 90-100, 100-110 and o6b, o6b overlaps with 90-100 and o6a.
 	o6a := BlockMeta{MinTime: 92, MaxTime: 105}
 	o6b := BlockMeta{MinTime: 94, MaxTime: 99}
-	testutil.Equals(t, [][]BlockMeta{{metas[9], o6a, o6b}, {o6a, metas[10]}}, OverlappingBlocks(append(metas, o6a, o6b)))
+	testutil.Equals(t, map[TimeRange][]BlockMeta{
+		{Min: 94, Max: 99}:   {metas[9], o6a, o6b},
+		{Min: 100, Max: 105}: {o6a, metas[10]},
+	}, OverlappingBlocks(append(metas, o6a, o6b)))
 
 	// All together.
-	testutil.Equals(t, [][]BlockMeta{
-		{metas[1], o1},
-		{metas[2], o2}, {o2, metas[3]},
-		{metas[3], o3a, o3b},
-		{metas[5], o4},
-		{metas[6], o5}, {o5, metas[7]}, {o5, metas[8]},
-		{metas[9], o6a, o6b}, {o6a, metas[10]},
+	testutil.Equals(t, map[TimeRange][]BlockMeta{
+		{Min: 15, Max: 17}: {metas[1], o1},
+		{Min: 21, Max: 30}: {metas[2], o2}, {Min: 30, Max: 31}: {o2, metas[3]},
+		{Min: 34, Max: 36}: {metas[3], o3a, o3b},
+		{Min: 50, Max: 60}: {metas[5], o4},
+		{Min: 61, Max: 70}: {metas[6], o5}, {Min: 70, Max: 80}: {o5, metas[7]}, {Min: 80, Max: 85}: {o5, metas[8]},
+		{Min: 94, Max: 99}: {metas[9], o6a, o6b}, {Min: 100, Max: 105}: {o6a, metas[10]},
 	}, OverlappingBlocks(append(metas, o1, o2, o3a, o3b, o4, o5, o6a, o6b)))
 
-	// Additional cases.
-	a1 := BlockMeta{MinTime: 1, MaxTime: 5}
-	a2 := BlockMeta{MinTime: 1, MaxTime: 2}
-	a3 := BlockMeta{MinTime: 3, MaxTime: 4}
-	a4 := BlockMeta{MinTime: 3, MaxTime: 4}
-	testutil.Equals(t, [][]BlockMeta{{a1, a2}, {a1, a3, a4}}, OverlappingBlocks(append([]BlockMeta{a1}, a2, a3, a4)))
-
+	// Additional case.
 	var nc1 []BlockMeta
 	nc1 = append(nc1, BlockMeta{MinTime: 1, MaxTime: 5})
 	nc1 = append(nc1, BlockMeta{MinTime: 2, MaxTime: 3})
@@ -959,10 +969,10 @@ func TestOverlappingBlocksDetectsAllOverlaps(t *testing.T) {
 	nc1 = append(nc1, BlockMeta{MinTime: 5, MaxTime: 7})
 	nc1 = append(nc1, BlockMeta{MinTime: 7, MaxTime: 10})
 	nc1 = append(nc1, BlockMeta{MinTime: 8, MaxTime: 9})
-	testutil.Equals(t, [][]BlockMeta{
-		{nc1[0], nc1[1], nc1[2], nc1[3], nc1[4], nc1[5]}, // 1-5, 2-3, 2-3, 2-3, 2-3, 2,6
-		{nc1[0], nc1[5], nc1[6]}, // 1-5, 2-6, 3-5
-		{nc1[5], nc1[7]}, // 2-6, 5-7
-		{nc1[8], nc1[9]}, // 7-10, 8-9
+	testutil.Equals(t, map[TimeRange][]BlockMeta{
+		{Min: 2, Max: 3}: {nc1[0], nc1[1], nc1[2], nc1[3], nc1[4], nc1[5]}, // 1-5, 2-3, 2-3, 2-3, 2-3, 2,6
+		{Min: 3, Max: 5}: {nc1[0], nc1[5], nc1[6]},                         // 1-5, 2-6, 3-5
+		{Min: 5, Max: 6}: {nc1[5], nc1[7]},                                 // 2-6, 5-7
+		{Min: 8, Max: 9}: {nc1[8], nc1[9]},                                 // 7-10, 8-9
 	}, OverlappingBlocks(nc1))
 }

--- a/db_test.go
+++ b/db_test.go
@@ -892,3 +892,47 @@ func expandSeriesSet(ss SeriesSet) ([]labels.Labels, error) {
 
 	return result, ss.Err()
 }
+
+func TestValidateBlockSequenceDetectsAllOverlaps(t *testing.T) {
+	var metas []BlockMeta
+
+	// Create 10 blocks that does not overlap (0-10, 10-20, ..., 90-100)
+	for i := 0; i < 10; i++ {
+		metas = append(metas, BlockMeta{MinTime: int64(i * 10), MaxTime: int64((i + 1) * 10)})
+	}
+
+	overlappedBlocks := ValidateBlockSequence(metas)
+	testutil.Assert(t, len(overlappedBlocks) == 0, "we found unexpected overlaps")
+
+	// Add overlaping blocks.
+
+	// o1 overlaps with 10-20.
+	o1 := BlockMeta{MinTime: 15, MaxTime: 17}
+
+	overlappedBlocks = ValidateBlockSequence(append(metas, o1))
+	expectedOverlaps := [][]BlockMeta{
+		{metas[1], o1},
+	}
+	testutil.Equals(t, expectedOverlaps, overlappedBlocks)
+
+	//// o2 overlaps with 20-30 and 30-40.
+	//o2 := BlockMeta{MinTime: 21, MaxTime: 31}
+	//
+	//// o3a and o3b overlaps with 30-40 and each other.
+	//o3a := BlockMeta{MinTime: 33, MaxTime: 39}
+	//o3b := BlockMeta{MinTime: 34, MaxTime: 36}
+	//
+	//// o4 is 1:1 overlap with 50-60
+	//o4 := BlockMeta{MinTime: 50, MaxTime: 60}
+	//
+	//// o5 overlaps with 50-60, 60-70 and 70,80
+	//o5 := BlockMeta{MinTime: 60, MaxTime: 80}
+	//
+
+	//expectedOverlaps := [][]block.Meta{
+	//	{metas[1], o1},
+	//	{metas[2], o2},
+	//	{metas[3], o2},
+	//	{metas[3], o3, o3b},
+	//}
+}

--- a/db_test.go
+++ b/db_test.go
@@ -930,4 +930,14 @@ func TestOverlappingBlocksDetectsAllOverlaps(t *testing.T) {
 	o6a := BlockMeta{MinTime: 92, MaxTime: 105}
 	o6b := BlockMeta{MinTime: 94, MaxTime: 99}
 	testutil.Equals(t, [][]BlockMeta{{metas[9], o6a, o6b}, {o6a, metas[10]}}, OverlappingBlocks(append(metas, o6a, o6b)))
+
+	// All together.
+	testutil.Equals(t, [][]BlockMeta{
+		{metas[1], o1},
+		{metas[2], o2}, {o2, metas[3]},
+		{metas[3], o3a, o3b},
+		{metas[5], o4},
+		{metas[6], o5}, {o5, metas[7]}, {o5, metas[8]},
+		{metas[9], o6a, o6b}, {o6a, metas[10]},
+	}, OverlappingBlocks(append(metas, o1, o2, o3a, o3b, o4, o5, o6a, o6b)))
 }


### PR DESCRIPTION
`validateBlockSequence` had bug (nothing updated the `prev` var) so only overlap in firs two blocks was detected.

This changes fixes that and prints all overlaps that are in system.
IMO it is useful to have this kind of algorithm exported here that other projects can reuse for proper overlap detection (e.g: thanos)