### PR TITLE
db: Match comment case to function name

### DIFF
--- a/db.go
+++ b/db.go
@@ -556,7 +556,7 @@ func (db *DB) reload(deleteable ...string) (err error) {
 	return errors.Wrap(db.head.Truncate(maxt), "head truncate failed")
 }
 
-// ValidateBlockSequence returns error if given block meta files indicate that some blocks overlaps within sequence.
+// validateBlockSequence returns error if given block meta files indicate that some blocks overlaps within sequence.
 func validateBlockSequence(bs []*Block) error {
 	if len(bs) <= 1 {
 		return nil


### PR DESCRIPTION
`validateBlockSequence` is not exported, make the letter case in the comment match the function name.