### PR TITLE
repair: improve error message

### DIFF
--- a/repair.go
+++ b/repair.go
@@ -20,11 +20,11 @@ func repairBadIndexVersion(logger log.Logger, dir string) error {
 	// We must actually set the index file version to 2 and revert the meta.json version back to 1.
 	dirs, err := blockDirs(dir)
 	if err != nil {
-		return errors.Wrapf(err, "list block dirs %s", dir)
+		return errors.Wrapf(err, "list block dirs in %q", dir)
 	}
 
 	wrapErr := func(err error, d string) error {
-		return errors.Wrapf(err, "block dir: %s", d)
+		return errors.Wrapf(err, "block dir: %q", d)
 	}
 	for _, d := range dirs {
 		meta, err := readBogusMetaFile(d)

--- a/repair.go
+++ b/repair.go
@@ -5,12 +5,10 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
-	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
 	"github.com/prometheus/tsdb/fileutil"
 )
@@ -20,20 +18,18 @@ import (
 func repairBadIndexVersion(logger log.Logger, dir string) error {
 	// All blocks written by Prometheus 2.1 with a meta.json version of 2 are affected.
 	// We must actually set the index file version to 2 and revert the meta.json version back to 1.
-	subdirs, err := fileutil.ReadDir(dir)
+	dirs, err := blockDirs(dir)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "list block dirs %s", dir)
 	}
-	for _, d := range subdirs {
-		// Skip non-block dirs.
-		if _, err := ulid.Parse(d); err != nil {
-			continue
-		}
-		d = path.Join(dir, d)
 
+	wrapErr := func(err error, d string) error {
+		return errors.Wrapf(err, "block dir: %s", d)
+	}
+	for _, d := range dirs {
 		meta, err := readBogusMetaFile(d)
 		if err != nil {
-			return err
+			return wrapErr(err, d)
 		}
 		if meta.Version == 1 {
 			level.Info(logger).Log(
@@ -53,35 +49,35 @@ func repairBadIndexVersion(logger log.Logger, dir string) error {
 
 		repl, err := os.Create(filepath.Join(d, "index.repaired"))
 		if err != nil {
-			return err
+			return wrapErr(err, d)
 		}
 		broken, err := os.Open(filepath.Join(d, "index"))
 		if err != nil {
-			return err
+			return wrapErr(err, d)
 		}
 		if _, err := io.Copy(repl, broken); err != nil {
-			return err
+			return wrapErr(err, d)
 		}
 		// Set the 5th byte to 2 to indiciate the correct file format version.
 		if _, err := repl.WriteAt([]byte{2}, 4); err != nil {
-			return err
+			return wrapErr(err, d)
 		}
 		if err := fileutil.Fsync(repl); err != nil {
-			return err
+			return wrapErr(err, d)
 		}
 		if err := repl.Close(); err != nil {
-			return err
+			return wrapErr(err, d)
 		}
 		if err := broken.Close(); err != nil {
-			return err
+			return wrapErr(err, d)
 		}
 		if err := renameFile(repl.Name(), broken.Name()); err != nil {
-			return err
+			return wrapErr(err, d)
 		}
 		// Reset version of meta.json to 1.
 		meta.Version = 1
 		if err := writeMetaFile(d, meta); err != nil {
-			return err
+			return wrapErr(err, d)
 		}
 	}
 	return nil


### PR DESCRIPTION
This fixes https://github.com/prometheus/prometheus/issues/4112.

Here is the log message for a Prometheus server using this PR.
```
level=error ts=2018-04-25T09:03:59.359148734Z caller=main.go:593 err="Opening storage failed block dir: data/01CBVVTQBW3VDA8Z7R2CKMM3F1: unexpected end of JSON input"
```