### PR TITLE
Seek() shouldn't return true when past maxt

### DIFF
--- a/querier.go
+++ b/querier.go
@@ -804,7 +804,10 @@ func (it *chunkSeriesIterator) Seek(t int64) (ok bool) {
 
 	for it.cur.Next() {
 		t0, _ := it.cur.At()
-		if t0 >= t && t0 <= it.maxt {
+		if t0 > it.maxt {
+			return false
+		}
+		if t0 >= t {
 			return true
 		}
 	}

--- a/querier.go
+++ b/querier.go
@@ -804,7 +804,7 @@ func (it *chunkSeriesIterator) Seek(t int64) (ok bool) {
 
 	for it.cur.Next() {
 		t0, _ := it.cur.At()
-		if t0 >= t {
+		if t0 >= t && t0 <= it.maxt {
 			return true
 		}
 	}
@@ -824,13 +824,9 @@ func (it *chunkSeriesIterator) Next() bool {
 				return false
 			}
 			t, _ = it.At()
+		}
 
-			return t <= it.maxt
-		}
-		if t > it.maxt {
-			return false
-		}
-		return true
+		return t <= it.maxt
 	}
 	if err := it.cur.Err(); err != nil {
 		return false

--- a/querier_test.go
+++ b/querier_test.go
@@ -390,6 +390,16 @@ func TestBlockQuerier(t *testing.T) {
 					},
 				},
 			},
+			{
+				lset: map[string]string{
+					"s": "s",
+				},
+				chunks: [][]sample{
+					{
+						{1, 2}, {10, 11},
+					},
+				},
+			},
 		},
 
 		queries: []query{
@@ -445,6 +455,18 @@ func TestBlockQuerier(t *testing.T) {
 						"x": "xyz",
 					},
 						[]sample{{2, 3}, {3, 4}, {5, 2}, {6, 3}},
+					),
+				}),
+			},
+			{
+				mint: 2,
+				maxt: 9,
+				ms:   []labels.Matcher{labels.NewEqualMatcher("s", "s")},
+				exp: newListSeriesSet([]Series{
+					newSeries(map[string]string{
+						"s": "s",
+					},
+						[]sample{},
 					),
 				}),
 			},
@@ -558,7 +580,7 @@ func TestBlockQuerierDelete(t *testing.T) {
 			},
 		},
 		tombstones: memTombstones{
-			1: Intervals{{1, 3}},
+			1: Intervals{{1, 2}},
 			2: Intervals{{1, 3}, {6, 10}},
 			3: Intervals{{6, 10}},
 		},
@@ -572,7 +594,7 @@ func TestBlockQuerierDelete(t *testing.T) {
 					newSeries(map[string]string{
 						"a": "a",
 					},
-						[]sample{{5, 2}, {6, 3}, {7, 4}},
+						[]sample{{3, 4}, {5, 2}, {6, 3}, {7, 4}},
 					),
 					newSeries(map[string]string{
 						"a": "a",
@@ -607,6 +629,11 @@ func TestBlockQuerierDelete(t *testing.T) {
 				exp: newListSeriesSet([]Series{
 					newSeries(map[string]string{
 						"a": "a",
+					},
+						[]sample{{3, 4}},
+					),
+					newSeries(map[string]string{
+						"a": "a",
 						"b": "b",
 					},
 						[]sample{{4, 15}},
@@ -615,9 +642,15 @@ func TestBlockQuerierDelete(t *testing.T) {
 			},
 			{
 				mint: 1,
-				maxt: 3,
+				maxt: 2,
 				ms:   []labels.Matcher{labels.NewEqualMatcher("a", "a")},
-				exp:  newListSeriesSet([]Series{}),
+				exp: newListSeriesSet([]Series{
+					newSeries(map[string]string{
+						"a": "a",
+					},
+						[]sample{},
+					),
+				}),
 			},
 		},
 	}
@@ -987,7 +1020,7 @@ func TestSeriesIterator(t *testing.T) {
 						{10, 22}, {203, 3493},
 					},
 
-					seek:    203,
+					seek:    100,
 					success: false,
 					exp:     nil,
 					mint:    2,

--- a/querier_test.go
+++ b/querier_test.go
@@ -1020,7 +1020,7 @@ func TestSeriesIterator(t *testing.T) {
 						{10, 22}, {203, 3493},
 					},
 
-					seek:    100,
+					seek:    101,
 					success: false,
 					exp:     nil,
 					mint:    2,


### PR DESCRIPTION
`Seek()` shouldn't return `true` when past `maxt`. Also add some tests to show that `Querier.Select()` may return series with no values.