### PR TITLE
Ensure correct block order on reload

### DIFF
--- a/block_test.go
+++ b/block_test.go
@@ -43,7 +43,7 @@ func TestSetCompactionFailed(t *testing.T) {
 	testutil.Ok(t, err)
 	defer os.RemoveAll(tmpdir)
 
-	b := createEmptyBlock(t, tmpdir)
+	b := createEmptyBlock(t, tmpdir, &BlockMeta{Version: 2})
 
 	testutil.Equals(t, false, b.meta.Compaction.Failed)
 	testutil.Ok(t, b.setCompactionFailed())
@@ -55,10 +55,11 @@ func TestSetCompactionFailed(t *testing.T) {
 	testutil.Equals(t, true, b.meta.Compaction.Failed)
 }
 
-func createEmptyBlock(t *testing.T, dir string) *Block {
+// createEmpty block creates a block with the given meta but without any data.
+func createEmptyBlock(t *testing.T, dir string, meta *BlockMeta) *Block {
 	testutil.Ok(t, os.MkdirAll(dir, 0777))
 
-	testutil.Ok(t, writeMetaFile(dir, &BlockMeta{Version: 2}))
+	testutil.Ok(t, writeMetaFile(dir, meta))
 
 	ir, err := index.NewWriter(filepath.Join(dir, indexFilename))
 	testutil.Ok(t, err)

--- a/db.go
+++ b/db.go
@@ -522,6 +522,9 @@ func (db *DB) reload(deleteable ...string) (err error) {
 		blocks = append(blocks, b)
 		exist[meta.ULID] = struct{}{}
 	}
+	sort.Slice(blocks, func(i, j int) bool {
+		return blocks[i].Meta().MinTime < blocks[j].Meta().MinTime
+	})
 
 	if err := validateBlockSequence(blocks); err != nil {
 		return errors.Wrap(err, "invalid block sequence")


### PR DESCRIPTION
Due to a regression blocks were no longer ordered by time before
being stored in memory. This made data intermittently become unavailable
for queries.

Backport from #332
 
@brian-brazil @krasi-georgiev This must be included in the vendor update in Prometheus before releasing.