### PR TITLE
chunks: fix potential "index out of range" error

### DIFF
--- a/chunks/chunks.go
+++ b/chunks/chunks.go
@@ -296,7 +296,7 @@ func newReader(bs []ByteSlice, cs []io.Closer, pool chunkenc.Pool) (*Reader, err
 		}
 		// Verify magic number.
 		if m := binary.BigEndian.Uint32(b.Range(0, 4)); m != MagicChunks {
-			return nil, fmt.Errorf("invalid magic number %x", m)
+			return nil, errors.Errorf("invalid magic number %x", m)
 		}
 	}
 	return &cr, nil
@@ -357,8 +357,8 @@ func (s *Reader) Chunk(ref uint64) (chunkenc.Chunk, error) {
 	r := b.Range(off, off+binary.MaxVarintLen32)
 
 	l, n := binary.Uvarint(r)
-	if n < 0 {
-		return nil, fmt.Errorf("reading chunk length failed")
+	if n <= 0 {
+		return nil, errors.Errorf("reading chunk length failed with %d", n)
 	}
 	r = b.Range(off+n, off+n+int(l))
 

--- a/chunks/chunks_test.go
+++ b/chunks/chunks_test.go
@@ -1,0 +1,28 @@
+// Copyright 2017 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chunks
+
+import (
+	"testing"
+
+	"github.com/prometheus/tsdb/testutil"
+)
+
+func TestReaderWithInvalidBuffer(t *testing.T) {
+	b := realByteSlice([]byte{0x81, 0x81, 0x81, 0x81, 0x81, 0x81})
+	r := &Reader{bs: []ByteSlice{b}}
+
+	_, err := r.Chunk(0)
+	testutil.NotOk(t, err)
+}

--- a/index/index.go
+++ b/index/index.go
@@ -740,8 +740,8 @@ func (r *Reader) decbufUvarintAt(off int) decbuf {
 	b := r.b.Range(off, off+binary.MaxVarintLen32)
 
 	l, n := binary.Uvarint(b)
-	if n > binary.MaxVarintLen32 {
-		return decbuf{e: errors.New("invalid uvarint")}
+	if n <= 0 || n > binary.MaxVarintLen32 {
+		return decbuf{e: errors.Errorf("invalid uvarint %d", n)}
 	}
 
 	if r.b.Len() < off+n+int(l)+4 {

--- a/index/index_test.go
+++ b/index/index_test.go
@@ -380,3 +380,11 @@ func TestPersistence_index_e2e(t *testing.T) {
 
 	testutil.Ok(t, ir.Close())
 }
+
+func TestReaderWithInvalidBuffer(t *testing.T) {
+	b := realByteSlice([]byte{0x81, 0x81, 0x81, 0x81, 0x81, 0x81})
+	r := &Reader{b: b}
+
+	db := r.decbufUvarintAt(0)
+	testutil.NotOk(t, db.err())
+}


### PR DESCRIPTION
When `binary.Uvarint()` fails, the returned number of bytes is less than or equal to zero. I'm not sure how it can happen except with corrupted data but an "index out of range" panic has been reported in https://github.com/prometheus/prometheus/issues/4128.