### PR TITLE
Limit the returned db.Querier to the requested time range

### DIFF
--- a/db.go
+++ b/db.go
@@ -784,7 +784,11 @@ func (db *DB) Querier(mint, maxt int64) (Querier, error) {
 		}
 	}
 	if maxt >= db.head.MinTime() {
-		blocks = append(blocks, db.head)
+		blocks = append(blocks, &rangeHead{
+			head: db.head,
+			mint: mint,
+			maxt: maxt,
+		})
 	}
 
 	sq := &querier{

--- a/querier.go
+++ b/querier.go
@@ -499,17 +499,10 @@ func (s *baseChunkSeries) Err() error { return s.err }
 
 func (s *baseChunkSeries) Next() bool {
 	var (
-		lset     labels.Labels
-		chkMetas []chunks.Meta
+		lset     = make(labels.Labels, len(s.lset))
+		chkMetas = make([]chunks.Meta, len(s.chks))
 		err      error
 	)
-
-	if lsetLen := len(s.lset); lsetLen > 0 {
-		lset = make(labels.Labels, lsetLen)
-	}
-	if chksLen := len(s.chks); chksLen > 0 {
-		chkMetas = make([]chunks.Meta, chksLen)
-	}
 
 	for s.p.Next() {
 		ref := s.p.At()

--- a/querier.go
+++ b/querier.go
@@ -498,9 +498,16 @@ func (s *baseChunkSeries) At() (labels.Labels, []chunks.Meta, Intervals) {
 func (s *baseChunkSeries) Err() error { return s.err }
 
 func (s *baseChunkSeries) Next() bool {
+	lsetLen := len(s.lset)
+	chksLen := len(s.chks)
+	if lsetLen == 0 {
+		lsetLen = 10
+		chksLen = 10
+	}
+
 	var (
-		lset     labels.Labels
-		chkMetas []chunks.Meta
+		lset     = make(labels.Labels, lsetLen)
+		chkMetas = make([]chunks.Meta, chksLen)
 		err      error
 	)
 

--- a/querier.go
+++ b/querier.go
@@ -498,18 +498,18 @@ func (s *baseChunkSeries) At() (labels.Labels, []chunks.Meta, Intervals) {
 func (s *baseChunkSeries) Err() error { return s.err }
 
 func (s *baseChunkSeries) Next() bool {
-	lsetLen := len(s.lset)
-	chksLen := len(s.chks)
-	if lsetLen == 0 {
-		lsetLen = 10
-		chksLen = 10
-	}
-
 	var (
-		lset     = make(labels.Labels, lsetLen)
-		chkMetas = make([]chunks.Meta, chksLen)
+		lset     labels.Labels
+		chkMetas []chunks.Meta
 		err      error
 	)
+
+	if lsetLen := len(s.lset); lsetLen > 0 {
+		lset = make(labels.Labels, lsetLen)
+	}
+	if chksLen := len(s.chks); chksLen > 0 {
+		chkMetas = make([]chunks.Meta, chksLen)
+	}
 
 	for s.p.Next() {
 		ref := s.p.At()


### PR DESCRIPTION
Limit the returned `db.Querier` to the requested time range. Preallocate the `baseChunkSeries.lset` and `baseChunkSeries.chks` slices to the previous series' slice sizes to avoid unnecessary grow slice reallocations.

Tested for correctness and performance against prometheus/prometheus head. [Before](https://github.com/prometheus/tsdb/files/2136119/before.txt) and [after](https://github.com/prometheus/tsdb/files/2136124/after.txt) [`bench_test`](https://github.com/prometheus/prometheus/blob/dd6781add2390eb2f2251e108f2ef835eba44b05/promql/bench_test.go) results ([comparison](https://github.com/prometheus/tsdb/files/2136145/benchcmp.txt)) show reductions of up to 40% in execution times and up to 90% in memory allocations in range queries for plain series retrievals.

These are somewhat inflated numbers, as the test uses a single in-memory block spanning 26.4 hours with timeseries at 10 second resolution, but non-negligible on my Prometheus setup (5 second scrape, 10 second eval), as one can clearly spot a sawtooth pattern with a 2 hour period in both memory and, more tellingly, CPU utilization:

![rangehead](https://user-images.githubusercontent.com/32070098/41899314-71258630-792c-11e8-9cb1-bdc3de62db19.png)
