### PR TITLE
add wrapper for migrate wal (MigrateWalIfExists)

### DIFF
--- a/db.go
+++ b/db.go
@@ -192,7 +192,7 @@ func Open(dir string, l log.Logger, r prometheus.Registerer, opts *Options) (db 
 	if err := repairBadIndexVersion(l, dir); err != nil {
 		return nil, err
 	}
-	// Migrate old WAL.
+	// Migrate old WAL if one exists.
 	if err := MigrateWAL(l, filepath.Join(dir, "wal")); err != nil {
 		return nil, errors.Wrap(err, "migrate WAL")
 	}


### PR DESCRIPTION
When reading the new WAL code I found the naming of this functionality a bit confusing. I've simply added a wrapper that does the check for an existing WAL in `dir` to `MigrateWalIfExists`, which in turn can call `migrateWal`.

Feel free to close if you prefer the old naming, I assume there may be a reason for not naming it this way in the first place.