### PR TITLE
clean up after running repair tests

### DIFF
--- a/fileutil/fileutil.go
+++ b/fileutil/fileutil.go
@@ -135,3 +135,5 @@ func Replace(from, to string) error {
 	}
 	return pdir.Close()
 }
+
+//

--- a/fileutil/fileutil.go
+++ b/fileutil/fileutil.go
@@ -1,68 +1,108 @@
-// Package fileutil provides utility methods used when dealing with the filesystem in tsdb.
-// It is largely copied from github.com/coreos/etcd/pkg/fileutil to avoid the
-// dependency chain it brings with it.
-// Please check github.com/coreos/etcd for licensing information.
-package fileutil
+package tsdb
 
 import (
 	"os"
-	"path/filepath"
-	"sort"
+	"testing"
+
+	"github.com/prometheus/tsdb/chunks"
+	"github.com/prometheus/tsdb/fileutil"
+	"github.com/prometheus/tsdb/index"
+	"github.com/prometheus/tsdb/labels"
+	"github.com/prometheus/tsdb/testutil"
 )
 
-// ReadDir returns the filenames in the given directory in sorted order.
-func ReadDir(dirpath string) ([]string, error) {
-	dir, err := os.Open(dirpath)
-	if err != nil {
-		return nil, err
-	}
-	defer dir.Close()
-	names, err := dir.Readdirnames(-1)
-	if err != nil {
-		return nil, err
-	}
-	sort.Strings(names)
-	return names, nil
-}
+func TestRepairBadIndexVersion(t *testing.T) {
+	// The broken index used in this test was written by the following script
+	// at a broken revision.
+	//
+	// func main() {
+	// 	w, err := index.NewWriter("index")
+	// 	if err != nil {
+	// 		panic(err)
+	// 	}
+	// 	err = w.AddSymbols(map[string]struct{}{
+	// 		"a": struct{}{},
+	// 		"b": struct{}{},
+	// 		"1": struct{}{},
+	// 		"2": struct{}{},
+	// 	})
+	// 	if err != nil {
+	// 		panic(err)
+	// 	}
+	// 	err = w.AddSeries(1, labels.FromStrings("a", "1", "b", "1"))
+	// 	if err != nil {
+	// 		panic(err)
+	// 	}
+	// 	err = w.AddSeries(2, labels.FromStrings("a", "2", "b", "1"))
+	// 	if err != nil {
+	// 		panic(err)
+	// 	}
+	// 	err = w.WritePostings("b", "1", index.NewListPostings([]uint64{1, 2}))
+	// 	if err != nil {
+	// 		panic(err)
+	// 	}
+	// 	if err := w.Close(); err != nil {
+	// 		panic(err)
+	// 	}
+	// }
+	const dbDir = "testdata/repair_index_version/01BZJ9WJQPWHGNC2W4J9TA62KC"
+	tmpDir := "testdata/repair_index_version/copy"
+	tmpDbDir := tmpDir + "/3MCNSQ8S31EHGJYWK5E1GPJWJZ"
 
-// Rename safely renames a file.
-func Rename(from, to string) error {
-	if err := os.Rename(from, to); err != nil {
-		return err
+	// Check the current db.
+	// In its current state, lookups should fail with the fixed code.
+	meta, err := readMetaFile(dbDir)
+	testutil.NotOk(t, err)
+
+	// Touch chunks dir in block.
+	os.MkdirAll(dbDir+"/chunks", 0777)
+	defer os.RemoveAll(dbDir + "/chunks")
+
+	r, err := index.NewFileReader(dbDir + "/index")
+	testutil.Ok(t, err)
+	p, err := r.Postings("b", "1")
+	testutil.Ok(t, err)
+	for p.Next() {
+		t.Logf("next ID %d", p.At())
+
+		var lset labels.Labels
+		testutil.NotOk(t, r.Series(p.At(), &lset, nil))
+	}
+	testutil.Ok(t, p.Err())
+	testutil.Ok(t, r.Close())
+
+	// Create a copy DB to run test against.
+	if err = fileutil.CopyDirs(dbDir, tmpDbDir); err != nil {
+		t.Fatal(err)
+	}
+	// defer os.RemoveAll(tmpDir)
+	// On DB opening all blocks in the base dir should be repaired.
+	db, err := Open(tmpDir, nil, nil, nil)
+	testutil.Ok(t, err)
+	db.Close()
+
+	r, err = index.NewFileReader(tmpDbDir + "/index")
+	testutil.Ok(t, err)
+	p, err = r.Postings("b", "1")
+	testutil.Ok(t, err)
+	res := []labels.Labels{}
+
+	for p.Next() {
+		t.Logf("next ID %d", p.At())
+
+		var lset labels.Labels
+		var chks []chunks.Meta
+		testutil.Ok(t, r.Series(p.At(), &lset, &chks))
+		res = append(res, lset)
 	}
 
-	// Directory was renamed; sync parent dir to persist rename.
-	pdir, err := OpenDir(filepath.Dir(to))
-	if err != nil {
-		return err
-	}
+	testutil.Ok(t, p.Err())
+	testutil.Equals(t, []labels.Labels{
+		{{"a", "1"}, {"b", "1"}},
+		{{"a", "2"}, {"b", "1"}},
+	}, res)
 
-	if err = Fsync(pdir); err != nil {
-		pdir.Close()
-		return err
-	}
-	return pdir.Close()
-}
-
-// Replace moves a file or directory to a new location and deletes any previous data.
-// It is not atomic.
-func Replace(from, to string) error {
-	if err := os.RemoveAll(to); err != nil {
-		return err
-	}
-	if err := os.Rename(from, to); err != nil {
-		return err
-	}
-
-	// Directory was renamed; sync parent dir to persist rename.
-	pdir, err := OpenDir(filepath.Dir(to))
-	if err != nil {
-		return err
-	}
-
-	if err = Fsync(pdir); err != nil {
-		pdir.Close()
-		return err
-	}
-	return pdir.Close()
+	meta, err = readMetaFile(tmpDbDir)
+	testutil.Ok(t, err)
+	testutil.Assert(t, meta.Version == 1, "unexpected meta version %d", meta.Version)
 }

--- a/fileutil/fileutil.go
+++ b/fileutil/fileutil.go
@@ -111,7 +111,6 @@ func Rename(from, to string) error {
 		return err
 	}
 	return pdir.Close()
-	//
 }
 
 // Replace moves a file or directory to a new location and deletes any previous data.

--- a/fileutil/fileutil.go
+++ b/fileutil/fileutil.go
@@ -111,6 +111,7 @@ func Rename(from, to string) error {
 		return err
 	}
 	return pdir.Close()
+	//
 }
 
 // Replace moves a file or directory to a new location and deletes any previous data.

--- a/fileutil/fileutil.go
+++ b/fileutil/fileutil.go
@@ -135,5 +135,3 @@ func Replace(from, to string) error {
 	}
 	return pdir.Close()
 }
-
-//

--- a/repair_test.go
+++ b/repair_test.go
@@ -70,7 +70,6 @@ func TestRepairBadIndexVersion(t *testing.T) {
 	}
 	testutil.Ok(t, p.Err())
 	testutil.Ok(t, r.Close())
-	// asdf
 
 	// Create a copy DB to run test against.
 	if err = fileutil.CopyDirs(dbDir, tmpDbDir); err != nil {

--- a/repair_test.go
+++ b/repair_test.go
@@ -106,3 +106,5 @@ func TestRepairBadIndexVersion(t *testing.T) {
 	testutil.Ok(t, err)
 	testutil.Assert(t, meta.Version == 1, "unexpected meta version %d", meta.Version)
 }
+
+//

--- a/repair_test.go
+++ b/repair_test.go
@@ -106,5 +106,3 @@ func TestRepairBadIndexVersion(t *testing.T) {
 	testutil.Ok(t, err)
 	testutil.Assert(t, meta.Version == 1, "unexpected meta version %d", meta.Version)
 }
-
-//

--- a/repair_test.go
+++ b/repair_test.go
@@ -75,7 +75,7 @@ func TestRepairBadIndexVersion(t *testing.T) {
 	if err = fileutil.CopyDirs(dbDir, tmpDbDir); err != nil {
 		t.Fatal(err)
 	}
-	// defer os.RemoveAll(tmpDir)
+	defer os.RemoveAll(tmpDir)
 	// On DB opening all blocks in the base dir should be repaired.
 	db, err := Open(tmpDir, nil, nil, nil)
 	testutil.Ok(t, err)

--- a/repair_test.go
+++ b/repair_test.go
@@ -70,6 +70,7 @@ func TestRepairBadIndexVersion(t *testing.T) {
 	}
 	testutil.Ok(t, p.Err())
 	testutil.Ok(t, r.Close())
+	// asdf
 
 	// Create a copy DB to run test against.
 	if err = fileutil.CopyDirs(dbDir, tmpDbDir); err != nil {

--- a/repair_test.go
+++ b/repair_test.go
@@ -5,10 +5,10 @@ import (
 	"testing"
 
 	"github.com/prometheus/tsdb/chunks"
-	"github.com/prometheus/tsdb/testutil"
-
+	"github.com/prometheus/tsdb/fileutil"
 	"github.com/prometheus/tsdb/index"
 	"github.com/prometheus/tsdb/labels"
+	"github.com/prometheus/tsdb/testutil"
 )
 
 func TestRepairBadIndexVersion(t *testing.T) {
@@ -45,15 +45,20 @@ func TestRepairBadIndexVersion(t *testing.T) {
 	// 		panic(err)
 	// 	}
 	// }
+	const dbDir = "testdata/repair_index_version/01BZJ9WJQPWHGNC2W4J9TA62KC"
+	tmpDir := "testdata/repair_index_version/copy"
+	tmpDbDir := tmpDir + "/3MCNSQ8S31EHGJYWK5E1GPJWJZ"
 
+	// Check the current db.
 	// In its current state, lookups should fail with the fixed code.
-	const dir = "testdata/repair_index_version/01BZJ9WJQPWHGNC2W4J9TA62KC/"
-	meta, err := readMetaFile(dir)
+	meta, err := readMetaFile(dbDir)
 	testutil.NotOk(t, err)
-	// Touch chunks dir in block.
-	os.MkdirAll(dir+"chunks", 0777)
 
-	r, err := index.NewFileReader(dir + "index")
+	// Touch chunks dir in block.
+	os.MkdirAll(dbDir+"/chunks", 0777)
+	defer os.RemoveAll(dbDir + "/chunks")
+
+	r, err := index.NewFileReader(dbDir + "/index")
 	testutil.Ok(t, err)
 	p, err := r.Postings("b", "1")
 	testutil.Ok(t, err)
@@ -66,12 +71,17 @@ func TestRepairBadIndexVersion(t *testing.T) {
 	testutil.Ok(t, p.Err())
 	testutil.Ok(t, r.Close())
 
+	// Create a copy DB to run test against.
+	if err = fileutil.CopyDirs(dbDir, tmpDbDir); err != nil {
+		t.Fatal(err)
+	}
+	// defer os.RemoveAll(tmpDir)
 	// On DB opening all blocks in the base dir should be repaired.
-	db, err := Open("testdata/repair_index_version", nil, nil, nil)
+	db, err := Open(tmpDir, nil, nil, nil)
 	testutil.Ok(t, err)
 	db.Close()
 
-	r, err = index.NewFileReader(dir + "index")
+	r, err = index.NewFileReader(tmpDbDir + "/index")
 	testutil.Ok(t, err)
 	p, err = r.Postings("b", "1")
 	testutil.Ok(t, err)
@@ -92,7 +102,7 @@ func TestRepairBadIndexVersion(t *testing.T) {
 		{{"a", "2"}, {"b", "1"}},
 	}, res)
 
-	meta, err = readMetaFile(dir)
+	meta, err = readMetaFile(tmpDbDir)
 	testutil.Ok(t, err)
 	testutil.Assert(t, meta.Version == 1, "unexpected meta version %d", meta.Version)
 }


### PR DESCRIPTION
I noticed that some files are changed and others are created when running tsdb tests
Signed-off-by: Callum Styan <callumstyan@gmail.com>