### PR TITLE
return ErrOutOfOrderSample even on the same appender

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -301,14 +301,14 @@ func TestOutOfOrderDatapointCausesError(t *testing.T) {
 	app := db.Appender()
 	_, err := app.Add(labels.Labels{}, 1, 0)
 	testutil.Ok(t, err)
-	_, err = app.Add(labels.Labels{}, 1, 0)
+	_, err = app.Add(labels.Labels{}, 0, 0)
 	testutil.Equals(t, ErrOutOfOrderSample, err)
 
 	testutil.Ok(t, app.Commit())
 
 	// Also test that it errors on a new appender as well.
 	app = db.Appender()
-	_, err = app.Add(labels.Labels{}, 1, 0)
+	_, err = app.Add(labels.Labels{}, 0, 0)
 	testutil.Equals(t, ErrOutOfOrderSample, err)
 	testutil.Ok(t, app.Rollback())
 }

--- a/db_test.go
+++ b/db_test.go
@@ -293,8 +293,8 @@ func TestAmendDatapointCausesError(t *testing.T) {
 	testutil.Ok(t, app.Rollback())
 }
 
-// TestNoOutOfOrderErrorAfterRollback ensures that a rollback resets the timestampl
-// so samples with smaller timestamp can be added after a rollback.
+// TestNoOutOfOrderErrorAfterRollback ensures that a rollback resets the timestamp
+// so samples with lower timestamp can be added after a rollback.
 func TestNoOutOfOrderErrorAfterRollback(t *testing.T) {
 	db, close := openTestDB(t, nil)
 	defer close()

--- a/db_test.go
+++ b/db_test.go
@@ -293,6 +293,26 @@ func TestAmendDatapointCausesError(t *testing.T) {
 	testutil.Ok(t, app.Rollback())
 }
 
+func TestOutOfOrderDatapointCausesError(t *testing.T) {
+	db, close := openTestDB(t, nil)
+	defer close()
+	defer db.Close()
+
+	app := db.Appender()
+	_, err := app.Add(labels.Labels{}, 1, 0)
+	testutil.Ok(t, err)
+	_, err = app.Add(labels.Labels{}, 1, 0)
+	testutil.Equals(t, ErrOutOfOrderSample, err)
+
+	testutil.Ok(t, app.Commit())
+
+	// Also test that it errors on a new appender as well.
+	app = db.Appender()
+	_, err = app.Add(labels.Labels{}, 1, 0)
+	testutil.Equals(t, ErrOutOfOrderSample, err)
+	testutil.Ok(t, app.Rollback())
+}
+
 func TestDuplicateNaNDatapointNoAmendError(t *testing.T) {
 	db, close := openTestDB(t, nil)
 	defer close()

--- a/db_test.go
+++ b/db_test.go
@@ -293,7 +293,25 @@ func TestAmendDatapointCausesError(t *testing.T) {
 	testutil.Ok(t, app.Rollback())
 }
 
-func TestOutOfOrderDatapointCausesError(t *testing.T) {
+// TestNoOutOfOrderErrorAfterRollback ensures that a rollback resets the timestampl
+// so samples with smaller timestamp can be added after a rollback.
+func TestNoOutOfOrderErrorAfterRollback(t *testing.T) {
+	db, close := openTestDB(t, nil)
+	defer close()
+	defer db.Close()
+
+	app := db.Appender()
+	_, err := app.Add(labels.Labels{}, 1, 0)
+	testutil.Ok(t, err)
+	testutil.Ok(t, app.Rollback())
+	_, err = app.Add(labels.Labels{}, 0, 0)
+	testutil.Ok(t, err)
+}
+
+// TestOutOfOrderCausesError ensures that adding a sample with a
+// timestamp lower than the last one returns an error.
+// Tests accross different appenders.
+func TestOutOfOrderCausesError(t *testing.T) {
 	db, close := openTestDB(t, nil)
 	defer close()
 	defer db.Close()


### PR DESCRIPTION
supersedes: https://github.com/prometheus/tsdb/pull/258

ping @gouthamve 


any pointers how to run some good benchmarking?

I have tried `tsdb bench write` which shows very mixed results. 

Signed-off-by: Krasi Georgiev <kgeorgie@redhat.com>