### PR TITLE
removed some unused code and moved mockSeriesSet in querier_test

### DIFF
--- a/block.go
+++ b/block.go
@@ -185,16 +185,10 @@ type BlockMetaCompaction struct {
 	Failed  bool        `json:"failed,omitempty"`
 }
 
-const (
-	flagNone = 0
-	flagStd  = 1
-)
-
 const indexFilename = "index"
 const metaFilename = "meta.json"
 
 func chunkDir(dir string) string { return filepath.Join(dir, "chunks") }
-func walDir(dir string) string   { return filepath.Join(dir, "wal") }
 
 func readMetaFile(dir string) (*BlockMeta, error) {
 	b, err := ioutil.ReadFile(filepath.Join(dir, metaFilename))

--- a/db_test.go
+++ b/db_test.go
@@ -247,7 +247,7 @@ Outer:
 			expSamples = append(expSamples, sample{ts, smpls[ts]})
 		}
 
-		expss := newListSeriesSet([]Series{
+		expss := newMockSeriesSet([]Series{
 			newSeries(map[string]string{"a": "b"}, expSamples),
 		})
 
@@ -474,7 +474,7 @@ Outer:
 			expSamples = append(expSamples, sample{ts, smpls[ts]})
 		}
 
-		expss := newListSeriesSet([]Series{
+		expss := newMockSeriesSet([]Series{
 			newSeries(map[string]string{"a": "b"}, expSamples),
 		})
 
@@ -753,7 +753,7 @@ func TestTombstoneClean(t *testing.T) {
 			expSamples = append(expSamples, sample{ts, smpls[ts]})
 		}
 
-		expss := newListSeriesSet([]Series{
+		expss := newMockSeriesSet([]Series{
 			newSeries(map[string]string{"a": "b"}, expSamples),
 		})
 

--- a/head_test.go
+++ b/head_test.go
@@ -357,7 +357,7 @@ Outer:
 			expSamples = append(expSamples, sample{ts, smpls[ts]})
 		}
 
-		expss := newListSeriesSet([]Series{
+		expss := newMockSeriesSet([]Series{
 			newSeries(map[string]string{"a": "b"}, expSamples),
 		})
 
@@ -555,7 +555,7 @@ func TestDelete_e2e(t *testing.T) {
 					))
 				}
 			}
-			expSs := newListSeriesSet(matchedSeries)
+			expSs := newMockSeriesSet(matchedSeries)
 			// Compare both SeriesSets.
 			for {
 				eok, rok := expSs.Next(), ss.Next()

--- a/querier.go
+++ b/querier.go
@@ -892,30 +892,6 @@ func (it *deletedIterator) Err() error {
 	return it.it.Err()
 }
 
-type mockSeriesSet struct {
-	next   func() bool
-	series func() Series
-	err    func() error
-}
-
-func (m *mockSeriesSet) Next() bool { return m.next() }
-func (m *mockSeriesSet) At() Series { return m.series() }
-func (m *mockSeriesSet) Err() error { return m.err() }
-
-func newListSeriesSet(list []Series) *mockSeriesSet {
-	i := -1
-	return &mockSeriesSet{
-		next: func() bool {
-			i++
-			return i < len(list)
-		},
-		series: func() Series {
-			return list[i]
-		},
-		err: func() error { return nil },
-	}
-}
-
 type errSeriesSet struct {
 	err error
 }

--- a/wal.go
+++ b/wal.go
@@ -741,15 +741,6 @@ func (w *SegmentWAL) Close() error {
 	return w.dirFile.Close()
 }
 
-const (
-	minSectorSize = 512
-
-	// walPageBytes is the alignment for flushing records to the backing Writer.
-	// It should be a multiple of the minimum sector size so that WAL can safely
-	// distinguish between torn writes and ordinary data corruption.
-	walPageBytes = 16 * minSectorSize
-)
-
 func (w *SegmentWAL) write(t WALEntryType, flag uint8, buf []byte) error {
 	// Cut to the next segment if the entry exceeds the file size unless it would also
 	// exceed the size of a new segment.


### PR DESCRIPTION
hijacked from https://github.com/prometheus/tsdb/pull/294

no functional changes, just some cleanup and moved mockSeriesSet in querier_test.go
Signed-off-by: Krasi Georgiev <kgeorgie@redhat.com>