### PR TITLE
Merge chunks together on compaction

### DIFF
--- a/block_test.go
+++ b/block_test.go
@@ -15,11 +15,14 @@ package tsdb
 
 import (
 	"io/ioutil"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/go-kit/kit/log"
 	"github.com/prometheus/tsdb/index"
+	"github.com/prometheus/tsdb/labels"
 	"github.com/prometheus/tsdb/testutil"
 )
 
@@ -72,4 +75,45 @@ func createEmptyBlock(t *testing.T, dir string, meta *BlockMeta) *Block {
 	b, err := OpenBlock(dir, nil)
 	testutil.Ok(t, err)
 	return b
+}
+
+// createPopulatedBlock creates a block with nSeries series, and nSamples samples.
+func createPopulatedBlock(tb testing.TB, dir string, nSeries, nSamples int) *Block {
+	head, err := NewHead(nil, nil, nil, 2*60*60*1000)
+	testutil.Ok(tb, err)
+	defer head.Close()
+
+	lbls, err := labels.ReadLabels("testdata/20kseries.json", nSeries)
+	testutil.Ok(tb, err)
+	refs := make([]uint64, nSeries)
+
+	for n := 0; n < nSamples; n++ {
+		app := head.Appender()
+		ts := n * 1000
+		for i, lbl := range lbls {
+			if refs[i] != 0 {
+				err := app.AddFast(refs[i], int64(ts), rand.Float64())
+				if err == nil {
+					continue
+				}
+			}
+			ref, err := app.Add(lbl, int64(ts), rand.Float64())
+			testutil.Ok(tb, err)
+			refs[i] = ref
+		}
+		err := app.Commit()
+		testutil.Ok(tb, err)
+	}
+
+	compactor, err := NewLeveledCompactor(nil, log.NewNopLogger(), []int64{1000000}, nil, true)
+	testutil.Ok(tb, err)
+
+	testutil.Ok(tb, os.MkdirAll(dir, 0777))
+
+	ulid, err := compactor.Write(dir, head, head.MinTime(), head.MaxTime(), nil)
+	testutil.Ok(tb, err)
+
+	blk, err := OpenBlock(filepath.Join(dir, ulid.String()), nil)
+	testutil.Ok(tb, err)
+	return blk
 }

--- a/compact.go
+++ b/compact.go
@@ -629,7 +629,7 @@ func (c *LeveledCompactor) populateBlock(blocks []BlockReader, meta *BlockMeta, 
 		}
 
 		if c.mergeSmallChunks {
-			if newChks, err := c.mergeChunks(chks, scaleChunkSize(meta.MaxTime-meta.MinTime)); err == nil {
+			if newChks, err := mergeChunks(chks, scaleChunkSize(meta.MaxTime-meta.MinTime)); err == nil {
 				chks = newChks
 			} else {
 				level.Warn(c.logger).Log("msg", "failed to merge chunks", "err", err)
@@ -692,7 +692,7 @@ func (c *LeveledCompactor) populateBlock(blocks []BlockReader, meta *BlockMeta, 
 	return nil
 }
 
-func (c *LeveledCompactor) mergeChunks(chks []chunks.Meta, maxSamples int) ([]chunks.Meta, error) {
+func mergeChunks(chks []chunks.Meta, maxSamples int) ([]chunks.Meta, error) {
 	newChks := make([]chunks.Meta, 0, len(chks))
 	for i := 0; i < len(chks); i++ {
 		// If the current chunk cannot be merged with future chunks, add it and move on.

--- a/compact.go
+++ b/compact.go
@@ -127,7 +127,7 @@ func newCompactorMetrics(r prometheus.Registerer) *compactorMetrics {
 }
 
 // NewLeveledCompactor returns a LeveledCompactor.
-func NewLeveledCompactor(r prometheus.Registerer, l log.Logger, ranges []int64, pool chunkenc.Pool) (*LeveledCompactor, error) {
+func NewLeveledCompactor(r prometheus.Registerer, l log.Logger, ranges []int64, pool chunkenc.Pool, mergeSmallChunks bool) (*LeveledCompactor, error) {
 	if len(ranges) == 0 {
 		return nil, errors.Errorf("at least one range must be provided")
 	}
@@ -139,7 +139,7 @@ func NewLeveledCompactor(r prometheus.Registerer, l log.Logger, ranges []int64, 
 		chunkPool:        pool,
 		logger:           l,
 		metrics:          newCompactorMetrics(r),
-		mergeSmallChunks: true,
+		mergeSmallChunks: mergeSmallChunks,
 	}, nil
 }
 

--- a/compact_test.go
+++ b/compact_test.go
@@ -644,7 +644,7 @@ func TestCompaction_populateBlock(t *testing.T) {
 				blocks = append(blocks, &mockBReader{ir: ir, cr: cr})
 			}
 
-			c, err := NewLeveledCompactor(nil, nil, []int64{0}, nil)
+			c, err := NewLeveledCompactor(nil, nil, []int64{0}, nil, false)
 			testutil.Ok(t, err)
 
 			meta := &BlockMeta{

--- a/compact_test.go
+++ b/compact_test.go
@@ -148,7 +148,7 @@ func TestNoPanicFor0Tombstones(t *testing.T) {
 		},
 	}
 
-	c, err := NewLeveledCompactor(nil, nil, []int64{50}, nil)
+	c, err := NewLeveledCompactor(nil, nil, []int64{50}, nil, false)
 	testutil.Ok(t, err)
 
 	c.plan(metas)
@@ -162,7 +162,7 @@ func TestLeveledCompactor_plan(t *testing.T) {
 		180,
 		540,
 		1620,
-	}, nil)
+	}, nil, false)
 	testutil.Ok(t, err)
 
 	cases := []struct {
@@ -325,7 +325,7 @@ func TestRangeWithFailedCompactionWontGetSelected(t *testing.T) {
 		240,
 		720,
 		2160,
-	}, nil)
+	}, nil, false)
 	testutil.Ok(t, err)
 
 	cases := []struct {
@@ -375,7 +375,7 @@ func TestCompactionFailWillCleanUpTempDir(t *testing.T) {
 		240,
 		720,
 		2160,
-	}, nil)
+	}, nil, false)
 	testutil.Ok(t, err)
 
 	tmpdir, err := ioutil.TempDir("", "test")

--- a/db.go
+++ b/db.go
@@ -48,6 +48,7 @@ var DefaultOptions = &Options{
 	RetentionDuration: 15 * 24 * 60 * 60 * 1000, // 15 days in milliseconds
 	BlockRanges:       ExponentialBlockRanges(int64(2*time.Hour)/1e6, 3, 5),
 	NoLockfile:        false,
+	MergeSmallChunks:  true,
 }
 
 // Options of the DB storage.
@@ -63,6 +64,9 @@ type Options struct {
 
 	// NoLockfile disables creation and consideration of a lock file.
 	NoLockfile bool
+
+	// MergeSmallChunks will merge smaller chunks during compaction.
+	MergeSmallChunks bool
 }
 
 // Appender allows appending a batch of data. It must be completed with a
@@ -249,7 +253,7 @@ func Open(dir string, l log.Logger, r prometheus.Registerer, opts *Options) (db 
 		db.lockf = lockf
 	}
 
-	db.compactor, err = NewLeveledCompactor(r, l, opts.BlockRanges, db.chunkPool)
+	db.compactor, err = NewLeveledCompactor(r, l, opts.BlockRanges, db.chunkPool, opts.MergeSmallChunks)
 	if err != nil {
 		return nil, errors.Wrap(err, "create leveled compactor")
 	}

--- a/querier_test.go
+++ b/querier_test.go
@@ -18,11 +18,10 @@ import (
 	"io/ioutil"
 	"math"
 	"math/rand"
-	"path/filepath"
+	"os"
 	"sort"
 	"testing"
 
-	"github.com/go-kit/kit/log"
 	"github.com/pkg/errors"
 	"github.com/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/tsdb/chunks"
@@ -1303,8 +1302,12 @@ func BenchmarkPersistedQueries(b *testing.B) {
 	for _, nSeries := range []int{10, 100} {
 		for _, nSamples := range []int{1000, 10000, 100000} {
 			b.Run(fmt.Sprintf("series=%d,samplesPerSeries=%d", nSeries, nSamples), func(b *testing.B) {
-				block, err := createBlock(nSeries, nSamples)
+				dir, err := ioutil.TempDir("", "bench_persisted")
 				testutil.Ok(b, err)
+				defer os.RemoveAll(dir)
+				block := createPopulatedBlock(b, dir, nSeries, nSamples)
+				defer block.Close()
+
 				q, err := NewBlockQuerier(block, block.Meta().MinTime, block.Meta().MaxTime)
 				testutil.Ok(b, err)
 				defer q.Close()
@@ -1325,58 +1328,6 @@ func BenchmarkPersistedQueries(b *testing.B) {
 			})
 		}
 	}
-}
-
-func createBlock(nSeries, nSamples int) (*Block, error) {
-	head, err := NewHead(nil, nil, nil, 2*60*60*1000)
-	if err != nil {
-		return nil, err
-	}
-
-	lbls, err := labels.ReadLabels("testdata/20kseries.json", nSeries)
-	if err != nil {
-		return nil, err
-	}
-	refs := make([]uint64, nSeries)
-
-	for n := 0; n < nSamples; n++ {
-		app := head.Appender()
-		ts := n * 1000
-		for i, lbl := range lbls {
-			if refs[i] != 0 {
-				err := app.AddFast(refs[i], int64(ts), rand.Float64())
-				if err == nil {
-					continue
-				}
-			}
-			ref, err := app.Add(lbl, int64(ts), rand.Float64())
-			if err != nil {
-				return nil, err
-			}
-			refs[i] = ref
-		}
-		err := app.Commit()
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	compactor, err := NewLeveledCompactor(nil, log.NewNopLogger(), []int64{1000000}, nil, true)
-	if err != nil {
-		return nil, err
-	}
-
-	tmpdir, err := ioutil.TempDir("", "test")
-	if err != nil {
-		return nil, err
-	}
-
-	ulid, err := compactor.Write(tmpdir, head, head.MinTime(), head.MaxTime(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return OpenBlock(filepath.Join(tmpdir, ulid.String()), nil)
 }
 
 type mockChunkReader map[uint64]chunkenc.Chunk

--- a/querier_test.go
+++ b/querier_test.go
@@ -1361,7 +1361,7 @@ func createBlock(nSeries, nSamples int) (*Block, error) {
 		}
 	}
 
-	compactor, err := NewLeveledCompactor(nil, log.NewNopLogger(), []int64{1000000}, nil)
+	compactor, err := NewLeveledCompactor(nil, log.NewNopLogger(), []int64{1000000}, nil, true)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
fixes: https://github.com/prometheus/tsdb/issues/236

This is a first pass at merging small chunks together into larger ones. Initial query benchmark results seem promising for when blocks become larger. This code currently takes the 120 samples per 2 hours plan used in the head and makes the chunk size proportionally larger as the block size increases.

benchcmp results between first and last commits:
```
benchmark                                                          old ns/op     new ns/op     delta
BenchmarkPersistedQueries/series=10,samplesPerSeries=1000-8        103098        106463        +3.26%
BenchmarkPersistedQueries/series=10,samplesPerSeries=10000-8       468642        259983        -44.52%
BenchmarkPersistedQueries/series=10,samplesPerSeries=100000-8      3987684       209855        -94.74%
BenchmarkPersistedQueries/series=100,samplesPerSeries=1000-8       863718        852374        -1.31%
BenchmarkPersistedQueries/series=100,samplesPerSeries=10000-8      4582881       2465040       -46.21%
BenchmarkPersistedQueries/series=100,samplesPerSeries=100000-8     47530956      1918334       -95.96%

benchmark                                                          old allocs     new allocs     delta
BenchmarkPersistedQueries/series=10,samplesPerSeries=1000-8        427            427            +0.00%
BenchmarkPersistedQueries/series=10,samplesPerSeries=10000-8       1977           1107           -44.01%
BenchmarkPersistedQueries/series=10,samplesPerSeries=100000-8      17267          877            -94.92%
BenchmarkPersistedQueries/series=100,samplesPerSeries=1000-8       3738           3738           +0.00%
BenchmarkPersistedQueries/series=100,samplesPerSeries=10000-8      19238          10538          -45.22%
BenchmarkPersistedQueries/series=100,samplesPerSeries=100000-8     172145         8238           -95.21%

benchmark                                                          old bytes     new bytes     delta
BenchmarkPersistedQueries/series=10,samplesPerSeries=1000-8        70499         70500         +0.00%
BenchmarkPersistedQueries/series=10,samplesPerSeries=10000-8       194376        123395        -36.52%
BenchmarkPersistedQueries/series=10,samplesPerSeries=100000-8      1317825       92106         -93.01%
BenchmarkPersistedQueries/series=100,samplesPerSeries=1000-8       341780        341780        +0.00%
BenchmarkPersistedQueries/series=100,samplesPerSeries=10000-8      1580558       870738        -44.91%
BenchmarkPersistedQueries/series=100,samplesPerSeries=100000-8     12815166      557849        -95.65%
```