### PR TITLE
Add msg parameter to Equals function in testutil

### DIFF
--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -61,7 +61,7 @@ func NotOk(tb testing.TB, err error) {
 func Equals(tb testing.TB, exp, act interface{}, msgAndArgs ...interface{}) {
 	if !reflect.DeepEqual(exp, act) {
 		_, file, line, _ := runtime.Caller(1)
-		fmt.Printf("\033[31m%s:%d:\n\n\texp: %#v\n\n\tgot: %#v%s\033[39m\n\n", filepath.Base(file), line, exp, act, formatMessage(msgAndArgs))
+		fmt.Printf("\033[31m%s:%d:%s\n\n\texp: %#v\n\n\tgot: %#v\033[39m\n\n", filepath.Base(file), line, formatMessage(msgAndArgs), exp, act)
 		tb.FailNow()
 	}
 }
@@ -70,8 +70,9 @@ func formatMessage(msgAndArgs []interface{}) string {
 	if len(msgAndArgs) == 0 {
 		return ""
 	}
-	if _, ok := msgAndArgs[0].(string); !ok {
-		return ""
+
+	if msg, ok := msgAndArgs[0].(string); ok {
+		return fmt.Sprintf("\n\nmsg: "+msg, msgAndArgs[1:]...)
 	}
-	return fmt.Sprintf(fmt.Sprintf("\n\nmsg: %s", msgAndArgs[0]), msgAndArgs[1:]...)
+	return ""
 }

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -58,10 +58,20 @@ func NotOk(tb testing.TB, err error) {
 }
 
 // Equals fails the test if exp is not equal to act.
-func Equals(tb testing.TB, exp, act interface{}) {
+func Equals(tb testing.TB, exp, act interface{}, msgAndArgs ...interface{}) {
 	if !reflect.DeepEqual(exp, act) {
 		_, file, line, _ := runtime.Caller(1)
-		fmt.Printf("\033[31m%s:%d:\n\n\texp: %#v\n\n\tgot: %#v\033[39m\n\n", filepath.Base(file), line, exp, act)
+		fmt.Printf("\033[31m%s:%d:\n\n\texp: %#v\n\n\tgot: %#v%s\033[39m\n\n", filepath.Base(file), line, exp, act, formatMessage(msgAndArgs))
 		tb.FailNow()
 	}
+}
+
+func formatMessage(msgAndArgs []interface{}) string {
+	if len(msgAndArgs) == 0 {
+		return ""
+	}
+	if _, ok := msgAndArgs[0].(string); !ok {
+		return ""
+	}
+	return fmt.Sprintf(fmt.Sprintf("\n\nmsg: %s", msgAndArgs[0]), msgAndArgs[1:]...)
 }

--- a/wal/wal_test.go
+++ b/wal/wal_test.go
@@ -144,7 +144,7 @@ func TestReader(t *testing.T) {
 			if j >= len(c.exp) {
 				t.Fatal("received more records than inserted")
 			}
-			testutil.Equals(t, c.exp[j], rec)
+			testutil.Equals(t, c.exp[j], rec, "Bytes within record did not match expected Bytes")
 		}
 		if !c.fail && r.Err() != nil {
 			t.Fatalf("unexpected error: %s", r.Err())
@@ -256,6 +256,7 @@ func TestWAL_Repair(t *testing.T) {
 			// We create 3 segments with 3 records each and then corrupt the 2nd record
 			// of the 2nd segment.
 			// As a result we want a repaired WAL with the first 4 records intact.
+			intactRecords := 4
 			w, err := NewSize(nil, nil, dir, 3*pageSize)
 			testutil.Ok(t, err)
 
@@ -306,7 +307,7 @@ func TestWAL_Repair(t *testing.T) {
 				result = append(result, append(b, r.Record()...))
 			}
 			testutil.Ok(t, r.Err())
-			testutil.Equals(t, 4, len(result))
+			testutil.Equals(t, intactRecords, len(result), "Wrong number of intact records")
 
 			for i, r := range result {
 				if !bytes.Equal(records[i], r) {


### PR DESCRIPTION
Fixes #390 
I can go through and attempt to add more meaningful messages as opposed to an empty string.

Signed-off-by: Camille Janicki <camille.janicki@gmail.com>
