### PR TITLE
Fix TestCorrectNumTombstones after #391

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -1320,7 +1320,7 @@ func TestCorrectNumTombstones(t *testing.T) {
 	}
 	testutil.Ok(t, app.Commit())
 
-	_, err := db.compact()
+	err := db.compact()
 	testutil.Ok(t, err)
 	testutil.Equals(t, 1, len(db.blocks))
 


### PR DESCRIPTION
@krasi-georgiev Apparently https://github.com/prometheus/tsdb/pull/391 was merged while https://github.com/prometheus/tsdb/pull/385 was still in review, hence the test was not updated. We need to merge this soon.

Signed-off-by: Ganesh Vernekar <cs15btech11018@iith.ac.in>