### PR TITLE
add a function to head/db to return a list of all series ID's in Head

### DIFF
--- a/db.go
+++ b/db.go
@@ -279,6 +279,11 @@ func (db *DB) Dir() string {
 	return db.dir
 }
 
+// AllSeriesIDs returns a slice of all the series ID's currently in Head.
+func (db *DB) AllSeriesIDs() []uint64 {
+	return db.head.allSeriesIDs()
+}
+
 func (db *DB) run() {
 	defer close(db.donec)
 

--- a/head.go
+++ b/head.go
@@ -829,6 +829,17 @@ func (h *Head) Delete(mint, maxt int64, ms ...labels.Matcher) error {
 	return nil
 }
 
+// allSeriesIDs returns a list of all the series reference ID's currently in Head.
+func (h *Head) allSeriesIDs() []uint64 {
+	var series []uint64
+	for _, s := range h.series.series {
+		for k := range s {
+			series = append(series, k)
+		}
+	}
+	return series
+}
+
 // gc removes data before the minimum timestamp from the head.
 func (h *Head) gc() {
 	// Only data strictly lower than this timestamp must be deleted.


### PR DESCRIPTION
As part of rewriting the remote write (https://github.com/prometheus/prometheus/pull/4588) I'm keeping track of series records that we read out of the WAL so we can use the reference ID's when reading samples records to build the full metric for sending. However, at the moment that map of reference ID's to labels could grow endlessly. Within TSDB's Head, when truncation it trims series references that are no longer relevant. In the remote write changes, I can detect when a checkpoint is created, and make the call to get the series ID's that this PR adds.

Signed-off-by: Callum Styan <callumstyan@gmail.com>