### PR TITLE
more descriptive var names and some more logging.

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -38,7 +38,7 @@ type CheckpointStats struct {
 	TotalTombstones   int // Processed tombstones including dropped ones.
 }
 
-// LastCheckpoint returns the directory name of the most recent checkpoint.
+// LastCheckpoint returns the directory name and index of the most recent checkpoint.
 // If dir does not contain any checkpoints, ErrNotFound is returned.
 func LastCheckpoint(dir string) (string, int, error) {
 	files, err := ioutil.ReadDir(dir)
@@ -55,18 +55,17 @@ func LastCheckpoint(dir string) (string, int, error) {
 		if !fi.IsDir() {
 			return "", 0, errors.Errorf("checkpoint %s is not a directory", fi.Name())
 		}
-		k, err := strconv.Atoi(fi.Name()[len(checkpointPrefix):])
+		idx, err := strconv.Atoi(fi.Name()[len(checkpointPrefix):])
 		if err != nil {
 			continue
 		}
-		return fi.Name(), k, nil
+		return fi.Name(), idx, nil
 	}
 	return "", 0, ErrNotFound
 }
 
-// DeleteCheckpoints deletes all checkpoints in dir that have an index
-// below n.
-func DeleteCheckpoints(dir string, n int) error {
+// DeleteCheckpoints deletes all checkpoints in dir below the provided index.
+func DeleteCheckpoints(dir string, index int) error {
 	var errs MultiError
 
 	files, err := ioutil.ReadDir(dir)
@@ -77,8 +76,8 @@ func DeleteCheckpoints(dir string, n int) error {
 		if !strings.HasPrefix(fi.Name(), checkpointPrefix) {
 			continue
 		}
-		k, err := strconv.Atoi(fi.Name()[len(checkpointPrefix):])
-		if err != nil || k >= n {
+		cpIdx, err := strconv.Atoi(fi.Name()[len(checkpointPrefix):])
+		if err != nil || cpIdx >= index {
 			continue
 		}
 		if err := os.RemoveAll(filepath.Join(dir, fi.Name())); err != nil {
@@ -90,7 +89,7 @@ func DeleteCheckpoints(dir string, n int) error {
 
 const checkpointPrefix = "checkpoint."
 
-// Checkpoint creates a compacted checkpoint of segments in range [m, n] in the given WAL.
+// Checkpoint creates a compacted checkpoint of segments in range [first, last] in the given WAL.
 // It includes the most recent checkpoint if it exists.
 // All series not satisfying keep and samples below mint are dropped.
 //
@@ -98,7 +97,7 @@ const checkpointPrefix = "checkpoint."
 // segmented format as the original WAL itself.
 // This makes it easy to read it through the WAL package and concatenate
 // it with the original WAL.
-func Checkpoint(w *wal.WAL, m, n int, keep func(id uint64) bool, mint int64) (*CheckpointStats, error) {
+func Checkpoint(w *wal.WAL, first, last int, keep func(id uint64) bool, mint int64) (*CheckpointStats, error) {
 	stats := &CheckpointStats{}
 
 	var sr io.Reader
@@ -107,27 +106,27 @@ func Checkpoint(w *wal.WAL, m, n int, keep func(id uint64) bool, mint int64) (*C
 	// files if there is an error somewhere.
 	var closers []io.Closer
 	{
-		lastFn, k, err := LastCheckpoint(w.Dir())
+		cpDir, cpIdx, err := LastCheckpoint(w.Dir())
 		if err != nil && err != ErrNotFound {
 			return nil, errors.Wrap(err, "find last checkpoint")
 		}
 		if err == nil {
-			if m > k+1 {
-				return nil, errors.New("unexpected gap to last checkpoint")
+			if first > cpIdx+1 {
+				return nil, fmt.Errorf("unexpected gap to last checkpoint. expected:%v, got:%v", cpIdx+1, first)
 			}
 			// Ignore WAL files below the checkpoint. They shouldn't exist to begin with.
-			m = k + 1
+			first = cpIdx + 1
 
-			last, err := wal.NewSegmentsReader(filepath.Join(w.Dir(), lastFn))
+			r, err := wal.NewSegmentsReader(filepath.Join(w.Dir(), cpDir))
 			if err != nil {
 				return nil, errors.Wrap(err, "open last checkpoint")
 			}
-			defer last.Close()
-			closers = append(closers, last)
-			sr = last
+			defer r.Close()
+			closers = append(closers, r)
+			sr = r
 		}
 
-		segsr, err := wal.NewSegmentsRangeReader(w.Dir(), m, n)
+		segsr, err := wal.NewSegmentsRangeReader(w.Dir(), first, last)
 		if err != nil {
 			return nil, errors.Wrap(err, "create segment reader")
 		}
@@ -141,7 +140,7 @@ func Checkpoint(w *wal.WAL, m, n int, keep func(id uint64) bool, mint int64) (*C
 		}
 	}
 
-	cpdir := filepath.Join(w.Dir(), fmt.Sprintf("checkpoint.%06d", n))
+	cpdir := filepath.Join(w.Dir(), fmt.Sprintf("checkpoint.%06d", last))
 	cpdirtmp := cpdir + ".tmp"
 
 	if err := os.MkdirAll(cpdirtmp, 0777); err != nil {

--- a/head.go
+++ b/head.go
@@ -418,12 +418,12 @@ func (h *Head) Init() error {
 	}
 
 	// Backfill the checkpoint first if it exists.
-	cp, n, err := LastCheckpoint(h.wal.Dir())
+	cpDir, cpIndex, err := LastCheckpoint(h.wal.Dir())
 	if err != nil && err != ErrNotFound {
 		return errors.Wrap(err, "find last checkpoint")
 	}
 	if err == nil {
-		sr, err := wal.NewSegmentsReader(filepath.Join(h.wal.Dir(), cp))
+		sr, err := wal.NewSegmentsReader(filepath.Join(h.wal.Dir(), cpDir))
 		if err != nil {
 			return errors.Wrap(err, "open checkpoint")
 		}
@@ -434,11 +434,11 @@ func (h *Head) Init() error {
 		if err := h.loadWAL(wal.NewReader(sr)); err != nil {
 			return errors.Wrap(err, "backfill checkpoint")
 		}
-		n++
+		cpIndex++
 	}
 
 	// Backfill segments from the last checkpoint onwards
-	sr, err := wal.NewSegmentsRangeReader(h.wal.Dir(), n, -1)
+	sr, err := wal.NewSegmentsRangeReader(h.wal.Dir(), cpIndex, -1)
 	if err != nil {
 		return errors.Wrap(err, "open WAL segments")
 	}
@@ -493,18 +493,18 @@ func (h *Head) Truncate(mint int64) (err error) {
 	}
 	start = time.Now()
 
-	m, n, err := h.wal.Segments()
+	first, last, err := h.wal.Segments()
 	if err != nil {
 		return errors.Wrap(err, "get segment range")
 	}
-	n-- // Never consider last segment for checkpoint.
-	if n < 0 {
+	last-- // Never consider last segment for checkpoint.
+	if last < 0 {
 		return nil // no segments yet.
 	}
 	// The lower third of segments should contain mostly obsolete samples.
 	// If we have less than three segments, it's not worth checkpointing yet.
-	n = m + (n-m)/3
-	if n <= m {
+	last = first + (last-first)/3
+	if last <= first {
 		return nil
 	}
 
@@ -512,18 +512,18 @@ func (h *Head) Truncate(mint int64) (err error) {
 		return h.series.getByID(id) != nil
 	}
 	h.metrics.checkpointCreationTotal.Inc()
-	if _, err = Checkpoint(h.wal, m, n, keep, mint); err != nil {
+	if _, err = Checkpoint(h.wal, first, last, keep, mint); err != nil {
 		h.metrics.checkpointCreationFail.Inc()
 		return errors.Wrap(err, "create checkpoint")
 	}
-	if err := h.wal.Truncate(n + 1); err != nil {
+	if err := h.wal.Truncate(last + 1); err != nil {
 		// If truncating fails, we'll just try again at the next checkpoint.
 		// Leftover segments will just be ignored in the future if there's a checkpoint
 		// that supersedes them.
 		level.Error(h.logger).Log("msg", "truncating segments failed", "err", err)
 	}
 	h.metrics.checkpointDeleteTotal.Inc()
-	if err := DeleteCheckpoints(h.wal.Dir(), n); err != nil {
+	if err := DeleteCheckpoints(h.wal.Dir(), last); err != nil {
 		// Leftover old checkpoints do not cause problems down the line beyond
 		// occupying disk space.
 		// They will just be ignored since a higher checkpoint exists.
@@ -533,7 +533,7 @@ func (h *Head) Truncate(mint int64) (err error) {
 	h.metrics.walTruncateDuration.Observe(time.Since(start).Seconds())
 
 	level.Info(h.logger).Log("msg", "WAL checkpoint complete",
-		"low", m, "high", n, "duration", time.Since(start))
+		"first", first, "last", last, "duration", time.Since(start))
 
 	return nil
 }


### PR DESCRIPTION
renamed some vars 
and added some params to the logging in relation to https://github.com/prometheus/prometheus/issues/4695

instead of plain logs it will also show the segment index for the operations.
```
level=warn ts=2018-10-03T10:17:44.434560097Z caller=wal.go:282 component=tsdb msg="deleting all segments behind corruption"
level=warn ts=2018-10-03T10:17:44.434581496Z caller=wal.go:304 component=tsdb msg="rewrite corrupted segment"
```

@codesome please have a quick look before I merge it.

Signed-off-by: Krasi Georgiev <kgeorgie@redhat.com>