### PR TITLE
Bring back old functionality of Checkpoint()

### DIFF
--- a/checkpoint_test.go
+++ b/checkpoint_test.go
@@ -137,9 +137,9 @@ func TestCheckpoint(t *testing.T) {
 	}
 	testutil.Ok(t, w.Close())
 
-	_, err = Checkpoint(w, 100, 106, func(x uint64) bool {
+	_, err = Checkpoint(nil, w, 100, 106, func(x uint64) bool {
 		return x%2 == 0
-	}, last/2)
+	}, last/2, nil, nil)
 	testutil.Ok(t, err)
 	testutil.Ok(t, w.Truncate(107))
 	testutil.Ok(t, DeleteCheckpoints(w.Dir(), 106))


### PR DESCRIPTION
As pointed by @fabxc here https://github.com/prometheus/tsdb/pull/396#discussion_r224167073, `Checkpoint` functionality should not be changed as it is exposed. 

In order to preserve the new metrics added in https://github.com/prometheus/tsdb/pull/396, there are 2 new arguments for `Checkpoint(...)` (can be `nil`).

/cc @krasi-georgiev 

Signed-off-by: Ganesh Vernekar <cs15btech11018@iith.ac.in>