### PR TITLE
log an error instead of blocking a wal truncation on checkpoint gaps.

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -112,9 +112,6 @@ func Checkpoint(w *wal.WAL, from, to int, keep func(id uint64) bool, mint int64)
 		}
 		last := idx + 1
 		if err == nil {
-			if from > last {
-				return nil, fmt.Errorf("unexpected gap to last checkpoint. expected:%v, requested:%v", last, from)
-			}
 			// Ignore WAL files below the checkpoint. They shouldn't exist to begin with.
 			from = last
 

--- a/head.go
+++ b/head.go
@@ -507,6 +507,11 @@ func (h *Head) Truncate(mint int64) (err error) {
 	if last <= first {
 		return nil
 	}
+	_, idx, err := LastCheckpoint(h.wal.Dir())
+	expFirst := idx + 1
+	if err == nil && first != expFirst {
+		level.Error(h.logger).Log("msg", "unexpected wal segment gap to last checkpoint", "expected", expFirst, "actual", first)
+	}
 
 	keep := func(id uint64) bool {
 		return h.series.getByID(id) != nil


### PR DESCRIPTION
missing wal segment blocks truncation and the wal grows indefinitely.  

An error log message should be enough to indicate a problem.

related to:  https://github.com/prometheus/prometheus/issues/4695

Signed-off-by: Krasi Georgiev <kgeorgie@redhat.com>