### PR TITLE
Allow manual compaction for tests when compaction is disabled globally.

### DIFF
--- a/db.go
+++ b/db.go
@@ -113,8 +113,8 @@ type DB struct {
 	stopc    chan struct{}
 
 	// cmtx is used to control compactions and deletions.
-	cmtx               sync.Mutex
-	compactionsEnabled bool
+	cmtx            sync.Mutex
+	autoCompactions bool
 }
 
 type dbMetrics struct {
@@ -123,6 +123,7 @@ type dbMetrics struct {
 	reloads              prometheus.Counter
 	reloadsFailed        prometheus.Counter
 	compactionsTriggered prometheus.Counter
+	compactionsSkipped   prometheus.Counter
 	cutoffs              prometheus.Counter
 	cutoffsFailed        prometheus.Counter
 	startTime            prometheus.GaugeFunc
@@ -164,6 +165,10 @@ func newDBMetrics(db *DB, r prometheus.Registerer) *dbMetrics {
 	m.compactionsTriggered = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "prometheus_tsdb_compactions_triggered_total",
 		Help: "Total number of triggered compactions for the partition.",
+	})
+	m.compactionsSkipped = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "prometheus_tsdb_compactions_skipped_total",
+		Help: "Total number of skipped compactions due to disabled auto compaction.",
 	})
 	m.cutoffs = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "prometheus_tsdb_retention_cutoffs_total",
@@ -226,14 +231,14 @@ func Open(dir string, l log.Logger, r prometheus.Registerer, opts *Options) (db 
 	}
 
 	db = &DB{
-		dir:                dir,
-		logger:             l,
-		opts:               opts,
-		compactc:           make(chan struct{}, 1),
-		donec:              make(chan struct{}),
-		stopc:              make(chan struct{}),
-		compactionsEnabled: true,
-		chunkPool:          chunkenc.NewPool(),
+		dir:             dir,
+		logger:          l,
+		opts:            opts,
+		compactc:        make(chan struct{}, 1),
+		donec:           make(chan struct{}),
+		stopc:           make(chan struct{}),
+		autoCompactions: true,
+		chunkPool:       chunkenc.NewPool(),
 	}
 	db.metrics = newDBMetrics(db, r)
 
@@ -300,14 +305,19 @@ func (db *DB) run() {
 		case <-db.compactc:
 			db.metrics.compactionsTriggered.Inc()
 
-			err := db.compact()
-			if err != nil {
-				level.Error(db.logger).Log("msg", "compaction failed", "err", err)
-				backoff = exponential(backoff, 1*time.Second, 1*time.Minute)
+			db.cmtx.Lock()
+			enabled := db.autoCompactions
+			db.cmtx.Unlock()
+			if enabled {
+				if err := db.compact(); err != nil {
+					level.Error(db.logger).Log("msg", "compaction failed", "err", err)
+					backoff = exponential(backoff, 1*time.Second, 1*time.Minute)
+				} else {
+					backoff = 0
+				}
 			} else {
-				backoff = 0
+				db.metrics.compactionsSkipped.Inc()
 			}
-
 		case <-db.stopc:
 			return
 		}
@@ -369,11 +379,6 @@ func (a dbAppender) Commit() error {
 func (db *DB) compact() (err error) {
 	db.cmtx.Lock()
 	defer db.cmtx.Unlock()
-
-	if !db.compactionsEnabled {
-		return nil
-	}
-
 	// Check whether we have pending head blocks that are ready to be persisted.
 	// They have the highest priority.
 	for {
@@ -736,7 +741,7 @@ func (db *DB) DisableCompactions() {
 	db.cmtx.Lock()
 	defer db.cmtx.Unlock()
 
-	db.compactionsEnabled = false
+	db.autoCompactions = false
 	level.Info(db.logger).Log("msg", "compactions disabled")
 }
 
@@ -745,7 +750,7 @@ func (db *DB) EnableCompactions() {
 	db.cmtx.Lock()
 	defer db.cmtx.Unlock()
 
-	db.compactionsEnabled = true
+	db.autoCompactions = true
 	level.Info(db.logger).Log("msg", "compactions enabled")
 }
 

--- a/db.go
+++ b/db.go
@@ -115,7 +115,8 @@ type DB struct {
 	// cmtx ensures that compactions and deletions don't run simultaneously.
 	cmtx sync.Mutex
 
-	// autoCompactMtx ensures that no compaction gets triggered while changing the autoCompactions var.
+	// autoCompactMtx ensures that no compaction gets triggered while
+	// changing the autoCompactions var.
 	autoCompactMtx  sync.Mutex
 	autoCompactions bool
 }
@@ -738,7 +739,7 @@ func (db *DB) Close() error {
 	return merr.Err()
 }
 
-// DisableCompactions disables compactions.
+// DisableCompactions disables auto compactions.
 func (db *DB) DisableCompactions() {
 	db.autoCompactMtx.Lock()
 	defer db.autoCompactMtx.Unlock()
@@ -747,7 +748,7 @@ func (db *DB) DisableCompactions() {
 	level.Info(db.logger).Log("msg", "compactions disabled")
 }
 
-// EnableCompactions enables compactions.
+// EnableCompactions enables auto compactions.
 func (db *DB) EnableCompactions() {
 	db.autoCompactMtx.Lock()
 	defer db.autoCompactMtx.Unlock()

--- a/db_test.go
+++ b/db_test.go
@@ -1364,7 +1364,8 @@ func TestDisableAutoCompactions(t *testing.T) {
 
 	testutil.Ok(t, app.Commit())
 
-	// Wait for a compaction to be skipped and check that no new blocks were created.
+	// Wait for a compaction to be triggered and  skipped and
+	// check that no new blocks were created.
 	m := &dto.Metric{}
 	for x := 0; x < 3; x++ {
 		db.metrics.compactionsSkipped.Write(m)

--- a/db_test.go
+++ b/db_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/tsdb/chunks"
 	"github.com/prometheus/tsdb/index"
 	"github.com/prometheus/tsdb/labels"
@@ -1336,4 +1337,50 @@ func TestCorrectNumTombstones(t *testing.T) {
 
 	testutil.Ok(t, db.Delete(9, 11, labels.NewEqualMatcher("foo", "bar")))
 	testutil.Equals(t, uint64(3), db.blocks[0].meta.Stats.NumTombstones)
+}
+
+// TestDisableCompactions checks that we can disable the
+// auto compaction and run compactions on demand.
+// This is needed for unit tests that rely on
+// checking state before and after a compaction.
+func TestDisableAutoCompactions(t *testing.T) {
+	db, close := openTestDB(t, nil)
+	defer close()
+	defer db.Close()
+
+	db.DisableCompactions()
+
+	blockRange := DefaultOptions.BlockRanges[0]
+	label := labels.FromStrings("foo", "bar")
+
+	app := db.Appender()
+
+	for i := int64(0); i < 3; i++ {
+		_, err := app.Add(label, i*blockRange, 0)
+		testutil.Ok(t, err)
+		_, err = app.Add(label, i*blockRange+1000, 0)
+		testutil.Ok(t, err)
+	}
+
+	testutil.Ok(t, app.Commit())
+
+	// Wait for a compaction to be skipped and check that no new blocks were created.
+	m := &dto.Metric{}
+	for x := 0; x < 3; x++ {
+		db.metrics.compactionsSkipped.Write(m)
+		if *m.Counter.Value > float64(0) {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if *m.Counter.Value == float64(0) {
+		t.Fatal("No compaction was skipped after the set timeout.")
+	}
+	testutil.Equals(t, 0, len(db.blocks))
+
+	// Running compactions manually should create a new block
+	// even when auto compaction is disabled.
+	err := db.compact()
+	testutil.Ok(t, err)
+	testutil.Equals(t, 1, len(db.blocks))
 }


### PR DESCRIPTION
for tests we need to control when a compaction happens so with this
change automated compaction can be disabled, but allow to run it
manually it tests.

fixes failing tests in : https://github.com/prometheus/tsdb/pull/374

cc @gouthamve , @codesome 

Signed-off-by: Krasi Georgiev <kgeorgie@redhat.com>