### PR TITLE
Fix slice index out of bounds panic

### DIFF
--- a/wal/wal.go
+++ b/wal/wal.go
@@ -707,7 +707,7 @@ type Reader struct {
 	rdr   io.Reader
 	err   error
 	rec   []byte
-	buf   [recordHeaderSize+pageSize]byte
+	buf   [recordHeaderSize + pageSize]byte
 	total int64 // total bytes processed.
 }
 

--- a/wal/wal.go
+++ b/wal/wal.go
@@ -707,7 +707,7 @@ type Reader struct {
 	rdr   io.Reader
 	err   error
 	rec   []byte
-	buf   [pageSize]byte
+	buf   [recordHeaderSize+pageSize]byte
 	total int64 // total bytes processed.
 }
 


### PR DESCRIPTION
r.buf is used for header and the page, if the actual page size is near pageSize buf[:k] goes out of bounds.
Pr produced on a mobile via the web editor, so beware of the formatting issues.

```

goroutine 167 [running]:
github.com/prometheus/prometheus/vendor/github.com/prometheus/tsdb/wal.(*Reader).next(0xc0074e0000, 0xc0135f2000, 0xc0138d3470)
        /go/src/github.com/prometheus/prometheus/vendor/github.com/prometheus/tsdb/wal/wal.go:739 +0x9a6
github.com/prometheus/prometheus/vendor/github.com/prometheus/tsdb/wal.(*Reader).Next(0xc0074e0000, 0x94416)
        /go/src/github.com/prometheus/prometheus/vendor/github.com/prometheus/tsdb/wal/wal.go:706 +0x2f
github.com/prometheus/prometheus/vendor/github.com/prometheus/tsdb.(*Head).loadWAL(0xc0001c0fd0, 0xc0074e0000, 0xc0071b1640, 0x1d1e5a0)
        /go/src/github.com/prometheus/prometheus/vendor/github.com/prometheus/tsdb/head.go:304 +0x266
github.com/prometheus/prometheus/vendor/github.com/prometheus/tsdb.(*Head).Init(0xc0001c0fd0, 0x0, 0x0)
        /go/src/github.com/prometheus/prometheus/vendor/github.com/prometheus/tsdb/head.go:411 +0x28d
github.com/prometheus/prometheus/vendor/github.com/prometheus/tsdb.Open(0x7fff9c72ff70, 0xb, 0x1d1d600, 0xc0002194d0, 0x1d30ec0, 0xc00018c3c0, 0xc000219500, 0xc00075ce80, 0x0, 0x0)
        /go/src/github.com/prometheus/prometheus/vendor/github.com/prometheus/tsdb/db.go:268 +0x55a
github.com/prometheus/prometheus/storage/tsdb.Open(0x7fff9c72ff70, 0xb, 0x1d1d600, 0xc0002194d0, 0x1d30ec0, 0xc00018c3c0, 0xc0003e19b8, 0x0, 0x0, 0x0)
        /go/src/github.com/prometheus/prometheus/storage/tsdb/tsdb.go:143 +0x285
main.main.func20(0x0, 0x0)
        /go/src/github.com/prometheus/prometheus/cmd/prometheus/main.go:555 +0x1e6
github.com/prometheus/prometheus/vendor/github.com/oklog/oklog/pkg/group.(*Group).Run.func1(0xc0007b2d20, 0xc00076a640, 0xc000187bf0)
        /go/src/github.com/prometheus/prometheus/vendor/github.com/oklog/oklog/pkg/group/group.go:38 +0x27
created by github.com/prometheus/prometheus/vendor/github.com/oklog/oklog/pkg/group.(*Group).Run
        /go/src/github.com/prometheus/prometheus/vendor/github.com/oklog/oklog/pkg/group/group.go:37 +0xbe
```