### PR TITLE
Using filepath.Join() instead of strings with slashes

### DIFF
--- a/cmd/tsdb/main.go
+++ b/cmd/tsdb/main.go
@@ -42,12 +42,12 @@ func main() {
 		cli                  = kingpin.New(filepath.Base(os.Args[0]), "CLI tool for tsdb")
 		benchCmd             = cli.Command("bench", "run benchmarks")
 		benchWriteCmd        = benchCmd.Command("write", "run a write performance benchmark")
-		benchWriteOutPath    = benchWriteCmd.Flag("out", "set the output path").Default("benchout/").String()
+		benchWriteOutPath    = benchWriteCmd.Flag("out", "set the output path").Default("benchout").String()
 		benchWriteNumMetrics = benchWriteCmd.Flag("metrics", "number of metrics to read").Default("10000").Int()
-		benchSamplesFile     = benchWriteCmd.Arg("file", "input file with samples data, default is (../../testdata/20kseries.json)").Default("../../testdata/20kseries.json").String()
+		benchSamplesFile     = benchWriteCmd.Arg("file", "input file with samples data, default is ("+filepath.Join("..", "testdata", "20kseries.json")+")").Default(filepath.Join("..", "testdata", "20kseries.json")).String()
 		listCmd              = cli.Command("ls", "list db blocks")
 		listCmdHumanReadable = listCmd.Flag("human-readable", "print human readable values").Short('h').Bool()
-		listPath             = listCmd.Arg("db path", "database path (default is benchout/storage)").Default("benchout/storage").String()
+		listPath             = listCmd.Arg("db path", "database path (default is "+filepath.Join("benchout", "storage")+")").Default(filepath.Join("benchout", "storage")).String()
 	)
 
 	switch kingpin.MustParse(cli.Parse(os.Args[1:])) {

--- a/head_test.go
+++ b/head_test.go
@@ -17,6 +17,7 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"os"
+	"path/filepath"
 	"sort"
 	"testing"
 
@@ -29,7 +30,7 @@ import (
 )
 
 func BenchmarkCreateSeries(b *testing.B) {
-	lbls, err := labels.ReadLabels("testdata/20kseries.json", b.N)
+	lbls, err := labels.ReadLabels(filepath.Join("testdata", "20kseries.json"), b.N)
 	testutil.Ok(b, err)
 
 	h, err := NewHead(nil, nil, nil, 10000)

--- a/index/index_test.go
+++ b/index/index_test.go
@@ -239,7 +239,7 @@ func TestPersistence_index_e2e(t *testing.T) {
 	testutil.Ok(t, err)
 	defer os.RemoveAll(dir)
 
-	lbls, err := labels.ReadLabels("../testdata/20kseries.json", 20000)
+	lbls, err := labels.ReadLabels(filepath.Join("..", "testdata", "20kseries.json"), 20000)
 	testutil.Ok(t, err)
 
 	// Sort labels as the index writer expects series in sorted order.

--- a/labels/labels_test.go
+++ b/labels/labels_test.go
@@ -16,6 +16,7 @@ package labels
 import (
 	"fmt"
 	"math/rand"
+	"path/filepath"
 	"sort"
 	"testing"
 
@@ -87,7 +88,7 @@ func TestCompareAndEquals(t *testing.T) {
 }
 
 func BenchmarkSliceSort(b *testing.B) {
-	lbls, err := ReadLabels("../testdata/20kseries.json", 20000)
+	lbls, err := ReadLabels(filepath.Join("..", "testdata", "20kseries.json"), 20000)
 	testutil.Ok(b, err)
 
 	for len(lbls) < 20e6 {

--- a/querier_test.go
+++ b/querier_test.go
@@ -19,6 +19,7 @@ import (
 	"math"
 	"math/rand"
 	"os"
+	"path/filepath"
 	"sort"
 	"testing"
 
@@ -1263,7 +1264,7 @@ func BenchmarkMergedSeriesSet(b *testing.B) {
 	} {
 		for _, j := range []int{1, 2, 4, 8, 16, 32} {
 			b.Run(fmt.Sprintf("series=%d,blocks=%d", k, j), func(b *testing.B) {
-				lbls, err := labels.ReadLabels("testdata/20kseries.json", k)
+				lbls, err := labels.ReadLabels(filepath.Join("testdata", "20kseries.json"), k)
 				testutil.Ok(b, err)
 
 				sort.Sort(labels.Slice(lbls))

--- a/wal_test.go
+++ b/wal_test.go
@@ -20,6 +20,7 @@ import (
 	"math/rand"
 	"os"
 	"path"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -76,7 +77,7 @@ func TestSegmentWAL_Truncate(t *testing.T) {
 		numMetrics = 20000
 		batch      = 100
 	)
-	series, err := labels.ReadLabels("testdata/20kseries.json", numMetrics)
+	series, err := labels.ReadLabels(filepath.Join("testdata", "20kseries.json"), numMetrics)
 	testutil.Ok(t, err)
 
 	dir, err := ioutil.TempDir("", "test_wal_log_truncate")
@@ -155,7 +156,7 @@ func TestSegmentWAL_Log_Restore(t *testing.T) {
 	)
 	// Generate testing data. It does not make semantical sense but
 	// for the purpose of this test.
-	series, err := labels.ReadLabels("testdata/20kseries.json", numMetrics)
+	series, err := labels.ReadLabels(filepath.Join("testdata", "20kseries.json"), numMetrics)
 	testutil.Ok(t, err)
 
 	dir, err := ioutil.TempDir("", "test_wal_log_restore")
@@ -272,11 +273,11 @@ func TestWALRestoreCorrupted_invalidSegment(t *testing.T) {
 	wal, err := OpenSegmentWAL(dir, nil, 0, nil)
 	testutil.Ok(t, err)
 
-	_, err = wal.createSegmentFile(dir + "/000000")
+	_, err = wal.createSegmentFile(filepath.Join(dir, "000000"))
 	testutil.Ok(t, err)
-	f, err := wal.createSegmentFile(dir + "/000001")
+	f, err := wal.createSegmentFile(filepath.Join(dir, "000001"))
 	testutil.Ok(t, err)
-	f2, err := wal.createSegmentFile(dir + "/000002")
+	f2, err := wal.createSegmentFile(filepath.Join(dir, "000002"))
 	testutil.Ok(t, err)
 	testutil.Ok(t, f2.Close())
 


### PR DESCRIPTION
fixes: https://github.com/prometheus/tsdb/issues/426
Using `filepath.Join()` instead of strings containing forward slash path delimiters (needed for non-*nix OSes), as suggested by @krasi-georgiev 

I hope it can be useful.

Thanks & best regards,
- Ben