### PR TITLE
FromMap(), sort and return instead of calling New()

### DIFF
--- a/labels/labels.go
+++ b/labels/labels.go
@@ -121,7 +121,8 @@ func FromMap(m map[string]string) Labels {
 	for k, v := range m {
 		l = append(l, Label{Name: k, Value: v})
 	}
-	return New(l...)
+	sort.Sort(Labels(l))
+	return l
 }
 
 // FromStrings creates new labels from pairs of strings.


### PR DESCRIPTION
FromMap(), is already creating a new slice for holding the labels, instead of creating a new one once again in call to New(), sort it and return.

Signed-off-by: nilsocket <nilsocket@gmail.com>