### PR TITLE
loop from the end, as readDir returns sorted output

### DIFF
--- a/chunks/chunks.go
+++ b/chunks/chunks.go
@@ -372,20 +372,21 @@ func (s *Reader) Chunk(ref uint64) (chunkenc.Chunk, error) {
 }
 
 func nextSequenceFile(dir string) (string, int, error) {
-	names, err := fileutil.ReadDir(dir)
+	names, err := fileutil.ReadDir(dir) //sorted
 	if err != nil {
 		return "", 0, err
 	}
 
-	i := uint64(0)
-	for _, n := range names {
-		j, err := strconv.ParseUint(n, 10, 64)
+	// dir may contain other than chunk files
+	for i := len(names) - 1; i > -1; i++ {
+		j, err := strconv.ParseUint(names[i], 10, 64)
 		if err != nil {
 			continue
 		}
-		i = j
+		return filepath.Join(dir, fmt.Sprintf("%0.6d", j+1)), int(j + 1), nil
 	}
-	return filepath.Join(dir, fmt.Sprintf("%0.6d", i+1)), int(i + 1), nil
+
+	return filepath.Join(dir, fmt.Sprintf("%0.6d", 1)), 1, nil
 }
 
 func sequenceFiles(dir string) ([]string, error) {


### PR DESCRIPTION
`ReadDir()` returns sorted output, and the next sequence number is going to be from last.

question: Is it better to return, this:
```go
return filepath.Join(dir, "000001"), 1, nil
```


Signed-off-by: nilsocket <nilsocket@gmail.com>