### PR TITLE
Don't panic for index out of bounds in reader.next

### DIFF
--- a/wal/wal.go
+++ b/wal/wal.go
@@ -752,6 +752,9 @@ func (r *Reader) next() (err error) {
 			if k == pageSize {
 				continue // Initial 0 byte was last page byte.
 			}
+			if int(k) > len(buf) {
+				return errors.New("read would result in slice bounds out of range")
+			}
 			n, err := io.ReadFull(r.rdr, buf[:k])
 			if err != nil {
 				return errors.Wrap(err, "read remaining zeros")


### PR DESCRIPTION
catch case in reader.next where we may try to access data outside the buffers slice bounds, avoid panic

This is mostly relevant to https://github.com/prometheus/prometheus/pull/4588, where we read from the WAL segment on every write event. For a series of write events we could read all of the data for subsequent write events in an earlier event, causing all later reads to panic (which at the moment I'm handling with a recover.

Signed-off-by: Callum Styan <callumstyan@gmail.com>

@gouthamve @fabxc 