### PR TITLE
Reduce memory taken up by posting/symbol tables.

### DIFF
--- a/block.go
+++ b/block.go
@@ -15,7 +15,6 @@
 package tsdb
 
 import (
-	"encoding/binary"
 	"encoding/json"
 	"io/ioutil"
 	"os"
@@ -274,23 +273,13 @@ func OpenBlock(dir string, pool chunkenc.Pool) (*Block, error) {
 		return nil, err
 	}
 
-	// Calculating symbol table size.
-	tmp := make([]byte, 8)
-	symTblSize := uint64(0)
-	for _, v := range ir.SymbolTable() {
-		// Size of varint length of the symbol.
-		symTblSize += uint64(binary.PutUvarint(tmp, uint64(len(v))))
-		// Size of the symbol.
-		symTblSize += uint64(len(v))
-	}
-
 	pb := &Block{
 		dir:             dir,
 		meta:            *meta,
 		chunkr:          cr,
 		indexr:          ir,
 		tombstones:      tr,
-		symbolTableSize: symTblSize,
+		symbolTableSize: ir.SymbolTableSize(),
 	}
 	return pb, nil
 }

--- a/index/index.go
+++ b/index/index.go
@@ -547,8 +547,10 @@ type Reader struct {
 	// block are always backed by true strings held in here rather than
 	// strings that are backed by byte slices from the mmap'd index file. This
 	// prevents memory faults when applications work with read symbols after
-	// the block has been unmapped.
-	symbols map[uint32]string
+	// the block has been unmapped. The older format has sparse indexes so a map
+	// must be used, but the new format is not so we can use a slice.
+	symbols     map[uint32]string
+	symbolSlice []string
 
 	dec *Decoder
 
@@ -629,11 +631,21 @@ func newReader(b ByteSlice, c io.Closer) (*Reader, error) {
 	}
 	var err error
 
+	// Use the strings already allocated by symbols, rather than
+	// re-allocating them again below.
+	symbols := make(map[string]string, len(r.symbols)+len(r.symbolSlice))
+	for _, s := range r.symbols {
+		symbols[s] = s
+	}
+	for _, s := range r.symbolSlice {
+		symbols[s] = s
+	}
+
 	err = r.readOffsetTable(r.toc.labelIndicesTable, func(key []string, off uint64) error {
 		if len(key) != 1 {
 			return errors.Errorf("unexpected key length %d", len(key))
 		}
-		r.labels[key[0]] = off
+		r.labels[symbols[key[0]]] = off
 		return nil
 	})
 	if err != nil {
@@ -643,14 +655,14 @@ func newReader(b ByteSlice, c io.Closer) (*Reader, error) {
 		if len(key) != 2 {
 			return errors.Errorf("unexpected key length %d", len(key))
 		}
-		r.postings[labels.Label{Name: key[0], Value: key[1]}] = off
+		r.postings[labels.Label{Name: symbols[key[0]], Value: symbols[key[1]]}] = off
 		return nil
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "read postings table")
 	}
 
-	r.dec = &Decoder{symbols: r.symbols}
+	r.dec = &Decoder{lookupSymbol: r.lookupSymbol}
 
 	return r, nil
 }
@@ -775,18 +787,17 @@ func (r *Reader) readSymbols(off int) error {
 		basePos = uint32(off) + 4
 		nextPos = basePos + uint32(origLen-d.len())
 	)
-
 	if r.version == 2 {
-		nextPos = 0
+		r.symbolSlice = make([]string, 0, cnt)
 	}
 
 	for d.err() == nil && d.len() > 0 && cnt > 0 {
 		s := d.uvarintStr()
-		r.symbols[nextPos] = s
 
 		if r.version == 2 {
-			nextPos++
+			r.symbolSlice = append(r.symbolSlice, s)
 		} else {
+			r.symbols[nextPos] = s
 			nextPos = basePos + uint32(origLen-d.len())
 		}
 		cnt--
@@ -826,6 +837,9 @@ func (r *Reader) Close() error {
 }
 
 func (r *Reader) lookupSymbol(o uint32) (string, error) {
+	if int(o) < len(r.symbolSlice) {
+		return r.symbolSlice[o], nil
+	}
 	s, ok := r.symbols[o]
 	if !ok {
 		return "", errors.Errorf("unknown symbol offset %d", o)
@@ -840,12 +854,22 @@ func (r *Reader) Symbols() (map[string]struct{}, error) {
 	for _, s := range r.symbols {
 		res[s] = struct{}{}
 	}
+	for _, s := range r.symbolSlice {
+		res[s] = struct{}{}
+	}
 	return res, nil
 }
 
 // SymbolTable returns the symbol table that is used to resolve symbol references.
-func (r *Reader) SymbolTable() map[uint32]string {
-	return r.symbols
+func (r *Reader) SymbolTableSize() uint64 {
+	var size int
+	for _, s := range r.symbols {
+		size += len(s) + 8
+	}
+	for _, s := range r.symbolSlice {
+		size += len(s) + 8
+	}
+	return uint64(size)
 }
 
 // LabelValues returns value tuples that exist for the given label name tuples.
@@ -1008,21 +1032,7 @@ func (t *serializedStringTuples) At(i int) ([]string, error) {
 // It currently does not contain decoding methods for all entry types but can be extended
 // by them if there's demand.
 type Decoder struct {
-	symbols map[uint32]string
-}
-
-func (dec *Decoder) lookupSymbol(o uint32) (string, error) {
-	s, ok := dec.symbols[o]
-	if !ok {
-		return "", errors.Errorf("unknown symbol offset %d", o)
-	}
-	return s, nil
-}
-
-// SetSymbolTable set the symbol table to be used for lookups when decoding series
-// and label indices
-func (dec *Decoder) SetSymbolTable(t map[uint32]string) {
-	dec.symbols = t
+	lookupSymbol func(uint32) (string, error)
 }
 
 // Postings returns a postings list for b and its number of elements.

--- a/index/index.go
+++ b/index/index.go
@@ -542,7 +542,7 @@ type Reader struct {
 
 	// Cached hashmaps of section offsets.
 	labels   map[string]uint64
-	postings map[labels.Label]uint64
+	postings map[string]map[string]uint64
 	// Cache of read symbols. Strings that are returned when reading from the
 	// block are always backed by true strings held in here rather than
 	// strings that are backed by byte slices from the mmap'd index file. This
@@ -606,7 +606,7 @@ func newReader(b ByteSlice, c io.Closer) (*Reader, error) {
 		c:        c,
 		symbols:  map[uint32]string{},
 		labels:   map[string]uint64{},
-		postings: map[labels.Label]uint64{},
+		postings: map[string]map[string]uint64{},
 		crc32:    newCRC32(),
 	}
 
@@ -651,11 +651,15 @@ func newReader(b ByteSlice, c io.Closer) (*Reader, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "read label index table")
 	}
+	r.postings[""] = map[string]uint64{}
 	err = r.readOffsetTable(r.toc.postingsTable, func(key []string, off uint64) error {
 		if len(key) != 2 {
 			return errors.Errorf("unexpected key length %d", len(key))
 		}
-		r.postings[labels.Label{Name: symbols[key[0]], Value: symbols[key[1]]}] = off
+		if _, ok := r.postings[key[0]]; !ok {
+			r.postings[symbols[key[0]]] = map[string]uint64{}
+		}
+		r.postings[key[0]][symbols[key[1]]] = off
 		return nil
 	})
 	if err != nil {
@@ -682,14 +686,16 @@ type Range struct {
 func (r *Reader) PostingsRanges() (map[labels.Label]Range, error) {
 	m := map[labels.Label]Range{}
 
-	for l, start := range r.postings {
-		d := r.decbufAt(int(start))
-		if d.err() != nil {
-			return nil, d.err()
-		}
-		m[l] = Range{
-			Start: int64(start) + 4,
-			End:   int64(start) + 4 + int64(d.len()),
+	for k, e := range r.postings {
+		for v, start := range e {
+			d := r.decbufAt(int(start))
+			if d.err() != nil {
+				return nil, d.err()
+			}
+			m[labels.Label{Name: k, Value: v}] = Range{
+				Start: int64(start) + 4,
+				End:   int64(start) + 4 + int64(d.len()),
+			}
 		}
 	}
 	return m, nil
@@ -935,10 +941,11 @@ func (r *Reader) Series(id uint64, lbls *labels.Labels, chks *[]chunks.Meta) err
 
 // Postings returns a postings list for the given label pair.
 func (r *Reader) Postings(name, value string) (Postings, error) {
-	off, ok := r.postings[labels.Label{
-		Name:  name,
-		Value: value,
-	}]
+	e, ok := r.postings[name]
+	if !ok {
+		return EmptyPostings(), nil
+	}
+	off, ok := e[value]
 	if !ok {
 		return EmptyPostings(), nil
 	}

--- a/index/index_test.go
+++ b/index/index_test.go
@@ -322,10 +322,12 @@ func TestPersistence_index_e2e(t *testing.T) {
 	testutil.Ok(t, err)
 	mi.WritePostings("", "", newListPostings(all))
 
-	for l := range postings.m {
-		err = iw.WritePostings(l.Name, l.Value, postings.Get(l.Name, l.Value))
-		testutil.Ok(t, err)
-		mi.WritePostings(l.Name, l.Value, postings.Get(l.Name, l.Value))
+	for n, e := range postings.m {
+		for v := range e {
+			err = iw.WritePostings(n, v, postings.Get(n, v))
+			testutil.Ok(t, err)
+			mi.WritePostings(n, v, postings.Get(n, v))
+		}
 	}
 
 	err = iw.Close()


### PR DESCRIPTION
Reuse the string already allocated for symbols
in the posting tables.

Use a slice for symbols in v2 format.

Move symbol size logic into the index code.
Avoid duplication of lookupSymbol logic.

On my test data with 100000 unique values for the label `llllllllllll` this brought index memory usage from 12.1MB  to 8.4MB.