### PR TITLE
Add WALSegmentSize as an option of tsdb creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## master / unreleased
 
+ - [CHANGE] New `WALSegmentSize` option to override the `DefaultOptions.WALSegmentSize`. Added to allow using smaller wal files. For example using tmpfs on a RPI to minimise the SD card wear out from the constant WAL writes. As part of this change the `DefaultOptions.WALSegmentSize` constant was also exposed.
+
 ## 0.3.0
 
  - [CHANGE] `LastCheckpoint()` used to return just the segment name and now it returns the full relative path.

--- a/wal/wal.go
+++ b/wal/wal.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	defaultSegmentSize = 128 * 1024 * 1024 // 128 MB
+	DefaultSegmentSize = 128 * 1024 * 1024 // 128 MB
 	pageSize           = 32 * 1024         // 32KB
 	recordHeaderSize   = 7
 )
@@ -174,7 +174,7 @@ type WAL struct {
 
 // New returns a new WAL over the given directory.
 func New(logger log.Logger, reg prometheus.Registerer, dir string) (*WAL, error) {
-	return NewSize(logger, reg, dir, defaultSegmentSize)
+	return NewSize(logger, reg, dir, DefaultSegmentSize)
 }
 
 // NewSize returns a new WAL over the given directory.


### PR DESCRIPTION
## Problem to solve :

Prometheus server is running on a raspberry pi : 
In order to preserve the SD Card lifetime, I mounted the WAL directory on the tmpfs (memory) partition.

The tmpfs partition is quickly full.

## Solution :

Provides the wal semgent file size as an option via `wal.Options` struct


### Results

Then, I will be able to limit the wal segment file sizes ( I set 1048576 for example ). Smaller files are written, and the oldest ones are truncated : the wal directory keep an acceptable size on tmpfs partition.

I prepared an [associated patch on prometheus server project](https://github.com/prometheus/prometheus/compare/v2.4.3...glutamatt:v2.4.3)

#### It [works perfectly](https://github.com/prometheus/tsdb/pull/450#issuecomment-437943996) on my raspberry now ✨


<details>
  <summary>output of the prometheus server on the raspberry when it crashed</summary>
  

```
level=warn ts=2018-11-10T03:17:09.556470872Z caller=scrape.go:804 component="scrape manager" scrape_pool=teleinfo target=http://localhost:2112/metrics msg="append failed" err="write to WAL: log samples: write /var/prometheus/data/wal/00000000: no space left on device"
panic: runtime error: slice bounds out of range

goroutine 180 [running]:
github.com/prometheus/prometheus/vendor/github.com/prometheus/tsdb/wal.(*WAL).log(0x33eaa20, 0x3d40000, 0x39, 0x400, 0x1, 0xfb9f8d30, 0x166)
        /go/src/github.com/prometheus/prometheus/vendor/github.com/prometheus/tsdb/wal/wal.go:480 +0x3ac
github.com/prometheus/prometheus/vendor/github.com/prometheus/tsdb/wal.(*WAL).Log(0x33eaa20, 0x39ebd54, 0x1, 0x1, 0x0, 0x0)
        /go/src/github.com/prometheus/prometheus/vendor/github.com/prometheus/tsdb/wal/wal.go:450 +0xc8
github.com/prometheus/prometheus/vendor/github.com/prometheus/tsdb.(*headAppender).log(0x344f9c0, 0x0, 0x0)
        /go/src/github.com/prometheus/prometheus/vendor/github.com/prometheus/tsdb/head.go:678 +0x158
github.com/prometheus/prometheus/vendor/github.com/prometheus/tsdb.(*headAppender).Commit(0x344f9c0, 0x0, 0x0)
        /go/src/github.com/prometheus/prometheus/vendor/github.com/prometheus/tsdb/head.go:689 +0xac
github.com/prometheus/prometheus/vendor/github.com/prometheus/tsdb.dbAppender.Commit(0x14f6228, 0x344f9c0, 0x30a2f50, 0x40080000, 0x0)
        /go/src/github.com/prometheus/prometheus/vendor/github.com/prometheus/tsdb/db.go:349 +0x24
github.com/prometheus/prometheus/storage/tsdb.appender.Commit(0x14f6468, 0x3c9db20, 0x0, 0xfb9f8d30)
        /go/src/github.com/prometheus/prometheus/storage/tsdb/tsdb.go:258 +0x24
github.com/prometheus/prometheus/storage.(*fanoutAppender).Commit(0x3bdfc20, 0x3c9db30, 0x0)
        /go/src/github.com/prometheus/prometheus/storage/fanout.go:161 +0x28
github.com/prometheus/prometheus/scrape.(*scrapeLoop).report(0x3f82640, 0x60f163df, 0xbef1b14d, 0x68485c3d, 0x5d7c, 0x233d9b0, 0x4006ce, 0x0, 0x3, 0x3, ...)
        /go/src/github.com/prometheus/prometheus/scrape/scrape.go:1127 +0x3b8
github.com/prometheus/prometheus/scrape.(*scrapeLoop).run(0x3f82640, 0x77359400, 0x0, 0x77359400, 0x0, 0x0)
        /go/src/github.com/prometheus/prometheus/scrape/scrape.go:818 +0x650
created by github.com/prometheus/prometheus/scrape.(*scrapePool).sync
        /go/src/github.com/prometheus/prometheus/scrape/scrape.go:329 +0x384
```
</details>