### PR TITLE
return an error when the  last wal segment record is torn.

### DIFF
--- a/wal/wal.go
+++ b/wal/wal.go
@@ -760,15 +760,12 @@ func (r *Reader) next() (err error) {
 		r.curRecTyp = recType(hdr[0])
 
 		// Gobble up zero bytes.
-<<<<<<< HEAD
-		if typ == recPageTerm {
-			// recPageTerm is a single byte that indicates that the rest of the page is padded.
-			// If it's the first byte in a page, buf is too small and we have to resize buf to fit pageSize-1 bytes.
+		if r.curRecTyp == recPageTerm {
+			// recPageTerm is a single byte that indicates the rest of the page is padded.
+			// If it's the first byte in a page, buf is too small and
+			// needs to be resized to fit pageSize-1 bytes.
 			buf = r.buf[1:]
 
-=======
-		if r.curRecTyp == recPageTerm {
->>>>>>> 2a55efd... return an error when the  last wal segment record is torn.
 			// We are pedantic and check whether the zeros are actually up
 			// to a page boundary.
 			// It's not strictly necessary but may catch sketchy state early.

--- a/wal/wal.go
+++ b/wal/wal.go
@@ -231,7 +231,7 @@ func NewSize(logger log.Logger, reg prometheus.Registerer, dir string, segmentSi
 			return nil, err
 		}
 	} else {
-		if w.segment, err = OpenWriteSegment(w.logger, w.dir, j); err != nil {
+		if w.segment, err = OpenWriteSegment(logger, w.dir, j); err != nil {
 			return nil, err
 		}
 		// Correctly initialize donePages.
@@ -713,11 +713,12 @@ func (r *segmentBufReader) Read(b []byte) (n int, err error) {
 
 // Reader reads WAL records from an io.Reader.
 type Reader struct {
-	rdr   io.Reader
-	err   error
-	rec   []byte
-	buf   [pageSize]byte
-	total int64 // total bytes processed.
+	rdr       io.Reader
+	err       error
+	rec       []byte
+	buf       [pageSize]byte
+	total     int64   // Total bytes processed.
+	curRecTyp recType // Used for checking that the last record is not torn.
 }
 
 // NewReader returns a new reader.
@@ -730,6 +731,12 @@ func NewReader(r io.Reader) *Reader {
 func (r *Reader) Next() bool {
 	err := r.next()
 	if errors.Cause(err) == io.EOF {
+		// The last WAL segment record shouldn't be torn(should be full or last).
+		// The last record would be torn after a crash just before
+		// the last record part could be persisted to disk.
+		if recType(r.curRecTyp) == recFirst || recType(r.curRecTyp) == recMiddle {
+			r.err = errors.New("last record is torn")
+		}
 		return false
 	}
 	r.err = err
@@ -750,14 +757,18 @@ func (r *Reader) next() (err error) {
 			return errors.Wrap(err, "read first header byte")
 		}
 		r.total++
-		typ := recType(hdr[0])
+		r.curRecTyp = recType(hdr[0])
 
 		// Gobble up zero bytes.
+<<<<<<< HEAD
 		if typ == recPageTerm {
 			// recPageTerm is a single byte that indicates that the rest of the page is padded.
 			// If it's the first byte in a page, buf is too small and we have to resize buf to fit pageSize-1 bytes.
 			buf = r.buf[1:]
 
+=======
+		if r.curRecTyp == recPageTerm {
+>>>>>>> 2a55efd... return an error when the  last wal segment record is torn.
 			// We are pedantic and check whether the zeros are actually up
 			// to a page boundary.
 			// It's not strictly necessary but may catch sketchy state early.
@@ -806,7 +817,7 @@ func (r *Reader) next() (err error) {
 		}
 		r.rec = append(r.rec, buf[:length]...)
 
-		switch typ {
+		switch r.curRecTyp {
 		case recFull:
 			if i != 0 {
 				return errors.New("unexpected full record")
@@ -826,7 +837,7 @@ func (r *Reader) next() (err error) {
 			}
 			return nil
 		default:
-			return errors.Errorf("unexpected record type %d", typ)
+			return errors.Errorf("unexpected record type %d", r.curRecTyp)
 		}
 		// Only increment i for non-zero records since we use it
 		// to determine valid content record sequences.


### PR DESCRIPTION
this ensures that a repair will be run when the last record in a segment is torn.

to reproduce:
 - kill Prometheus just after a first record is written (before a last record is written).
 - Start Prometheus. It show no signs of the issue and continues to write records after the torn record. This triggers a dead loop at checkpointing.

most likely the cause for:
https://github.com/prometheus/prometheus/issues/4695
~https://github.com/prometheus/prometheus/issues/4842~

cc @fabxc , @SuperQ 	


note to myself :smiling_imp: 
the wal records are grouped and written in pages, each  page is [32kb](https://github.com/prometheus/tsdb/blob/171fc4ab5da16793145d0e1df4403a073b1d2f78/wal/wal.go#L40) and when the last record doesn't fit in the current page it is split in parts(first,last). So the last record of one page would have the first part of a record and the first record in the next page would have the last part of a record.
So in case of a crash just after writing the first part the next WAL read didn't have a  check to trigger a repair in such cases and the PR fixes this.


Signed-off-by: Krasi Georgiev <kgeorgie@redhat.com>
