### PR TITLE
LabelNames() for Querier

### DIFF
--- a/db.go
+++ b/db.go
@@ -882,49 +882,6 @@ func (db *DB) CleanTombstones() (err error) {
 	return errors.Wrap(db.reload(), "reload blocks")
 }
 
-// labelNames returns all the unique label names from the Block Readers.
-func labelNames(brs ...BlockReader) (map[string]struct{}, error) {
-	labelNamesMap := make(map[string]struct{})
-	for _, br := range brs {
-		ir, err := br.Index()
-		if err != nil {
-			return nil, errors.Wrap(err, "get IndexReader")
-		}
-		names, err := ir.LabelNames()
-		if err != nil {
-			return nil, errors.Wrap(err, "LabelNames() from IndexReader")
-		}
-		for _, name := range names {
-			labelNamesMap[name] = struct{}{}
-		}
-		if err = ir.Close(); err != nil {
-			return nil, errors.Wrap(err, "close IndexReader")
-		}
-	}
-	return labelNamesMap, nil
-}
-
-// LabelNames returns all the unique label names present in the DB in sorted order.
-func (db *DB) LabelNames() ([]string, error) {
-	brs := []BlockReader{db.head}
-	for _, b := range db.Blocks() {
-		brs = append(brs, b)
-	}
-
-	labelNamesMap, err := labelNames(brs...)
-	if err != nil {
-		return nil, err
-	}
-
-	labelNames := make([]string, 0, len(labelNamesMap))
-	for name := range labelNamesMap {
-		labelNames = append(labelNames, name)
-	}
-	sort.Strings(labelNames)
-
-	return labelNames, nil
-}
-
 func isBlockDir(fi os.FileInfo) bool {
 	if !fi.IsDir() {
 		return false

--- a/db_test.go
+++ b/db_test.go
@@ -1388,12 +1388,15 @@ func TestDB_LabelNames(t *testing.T) {
 		}
 
 		// Addings more samples to head with new label names
-		// so that we can test db.LabelNames() (the union).
+		// so that we can test (head+disk).LabelNames() (the union).
 		appendSamples(db, 5, 9, tst.sampleLabels2)
 
 		// Testing DB (union).
-		labelNames, err = db.LabelNames()
+		q, err := db.Querier(math.MinInt64, math.MaxInt64)
 		testutil.Ok(t, err)
+		labelNames, err = q.LabelNames()
+		testutil.Ok(t, err)
+		testutil.Ok(t, q.Close())
 		testutil.Equals(t, tst.exp2, labelNames)
 	}
 }

--- a/querier.go
+++ b/querier.go
@@ -37,6 +37,9 @@ type Querier interface {
 	// under the constraint of another label.
 	LabelValuesFor(string, labels.Label) ([]string, error)
 
+	// LabelNames returns all the unique label names present in the block in sorted order.
+	LabelNames() ([]string, error)
+
 	// Close releases the resources of the Querier.
 	Close() error
 }
@@ -58,6 +61,28 @@ type querier struct {
 
 func (q *querier) LabelValues(n string) ([]string, error) {
 	return q.lvals(q.blocks, n)
+}
+
+// LabelNames returns all the unique label names present querier blocks.
+func (q *querier) LabelNames() ([]string, error) {
+	labelNamesMap := make(map[string]struct{})
+	for _, b := range q.blocks {
+		names, err := b.LabelNames()
+		if err != nil {
+			return nil, errors.Wrap(err, "LabelNames() from IndexReader")
+		}
+		for _, name := range names {
+			labelNamesMap[name] = struct{}{}
+		}
+	}
+
+	labelNames := make([]string, 0, len(labelNamesMap))
+	for name := range labelNamesMap {
+		labelNames = append(labelNames, name)
+	}
+	sort.Strings(labelNames)
+
+	return labelNames, nil
 }
 
 func (q *querier) lvals(qs []Querier, n string) ([]string, error) {
@@ -185,6 +210,10 @@ func (q *blockQuerier) LabelValues(name string) ([]string, error) {
 		res = append(res, vals[0])
 	}
 	return res, nil
+}
+
+func (q *blockQuerier) LabelNames() ([]string, error) {
+	return q.index.LabelNames()
 }
 
 func (q *blockQuerier) LabelValuesFor(string, labels.Label) ([]string, error) {

--- a/querier.go
+++ b/querier.go
@@ -33,6 +33,7 @@ type Querier interface {
 
 	// LabelValues returns all potential values for a label name.
 	LabelValues(string) ([]string, error)
+
 	// LabelValuesFor returns all potential values for a label name.
 	// under the constraint of another label.
 	LabelValuesFor(string, labels.Label) ([]string, error)
@@ -69,7 +70,7 @@ func (q *querier) LabelNames() ([]string, error) {
 	for _, b := range q.blocks {
 		names, err := b.LabelNames()
 		if err != nil {
-			return nil, errors.Wrap(err, "LabelNames() from IndexReader")
+			return nil, errors.Wrap(err, "LabelNames() from Querier")
 		}
 		for _, name := range names {
 			labelNamesMap[name] = struct{}{}


### PR DESCRIPTION
https://github.com/prometheus/prometheus/pull/4835 requires the `LabelNames()` function to be in the `Querier`. This PR removes it from the `DB` and adds it to `Querier`.