### PR TITLE
Make newBReader return a struct, not a pointer.

### DIFF
--- a/chunkenc/bstream.go
+++ b/chunkenc/bstream.go
@@ -49,8 +49,8 @@ type bstream struct {
 	count  uint8  // how many bits are valid in current byte
 }
 
-func newBReader(b []byte) *bstream {
-	return &bstream{stream: b, count: 8}
+func newBReader(b []byte) bstream {
+	return bstream{stream: b, count: 8}
 }
 
 func newBWriter(size int) *bstream {

--- a/chunkenc/xor.go
+++ b/chunkenc/xor.go
@@ -221,7 +221,7 @@ func (a *xorAppender) writeVDelta(v float64) {
 }
 
 type xorIterator struct {
-	br       *bstream
+	br       bstream
 	numTotal uint16
 	numRead  uint16
 
@@ -249,7 +249,7 @@ func (it *xorIterator) Next() bool {
 	}
 
 	if it.numRead == 0 {
-		t, err := binary.ReadVarint(it.br)
+		t, err := binary.ReadVarint(&it.br)
 		if err != nil {
 			it.err = err
 			return false
@@ -266,7 +266,7 @@ func (it *xorIterator) Next() bool {
 		return true
 	}
 	if it.numRead == 1 {
-		tDelta, err := binary.ReadUvarint(it.br)
+		tDelta, err := binary.ReadUvarint(&it.br)
 		if err != nil {
 			it.err = err
 			return false


### PR DESCRIPTION
This shows up as a hot spot in profiles of queries involving lots of seeks, as each seek creates a new iterator.

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>