### PR TITLE
Reload after reading the WAL.

### DIFF
--- a/db.go
+++ b/db.go
@@ -271,11 +271,11 @@ func Open(dir string, l log.Logger, r prometheus.Registerer, opts *Options) (db 
 	if err != nil {
 		return nil, err
 	}
-	if err := db.reload(); err != nil {
-		return nil, err
-	}
 	if err := db.head.Init(); err != nil {
 		return nil, errors.Wrap(err, "read WAL")
+	}
+	if err := db.reload(); err != nil {
+		return nil, err
 	}
 
 	go db.run()


### PR DESCRIPTION
This causes the head to be GCed at startup,
removing any series that were read from the WAL
but have since been written to a block. In
systems with low ingestion rates, this potentially
could be many many hours of data.

Signed-off-by: Brian Brazil <brian.brazil@robustperception.io>