### PR TITLE
fix some typos

### DIFF
--- a/repair.go
+++ b/repair.go
@@ -71,7 +71,7 @@ func repairBadIndexVersion(logger log.Logger, dir string) error {
 		if _, err := io.Copy(repl, broken); err != nil {
 			return wrapErr(err, d)
 		}
-		// Set the 5th byte to 2 to indiciate the correct file format version.
+		// Set the 5th byte to 2 to indicate the correct file format version.
 		if _, err := repl.WriteAt([]byte{2}, 4); err != nil {
 			return wrapErr(err, d)
 		}

--- a/wal.go
+++ b/wal.go
@@ -322,7 +322,7 @@ func (w *SegmentWAL) putBuffer(b *encbuf) {
 }
 
 // Truncate deletes the values prior to mint and the series which the keep function
-// does not indiciate to preserve.
+// does not indicate to preserve.
 func (w *SegmentWAL) Truncate(mint int64, keep func(uint64) bool) error {
 	// The last segment is always active.
 	if len(w.files) < 2 {


### PR DESCRIPTION
Signed-off-by: JoeWrightss <zhoulin.xie@daocloud.io>

fixs typo: "indiciate" -> "indicate" in [repair.go](https://github.com/prometheus/tsdb/compare/master...JoeWrightss:patch-2?expand=1#diff-5761ef8f9143ed50cee5543ace6ea5a1) and [wal.go](https://github.com/prometheus/tsdb/compare/master...JoeWrightss:patch-2?expand=1#diff-46120259e49a1a2fead3770611f7c32b)