### PR TITLE
remove unused WALFlushInterval option and NopWAL struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## master / unreleased
 
+ - [CLEANUP] `Options.WALFlushInterval` is removed as it wasn't used anywhere.
+
 ## 0.3.0
 
  - [CHANGE] `LastCheckpoint()` used to return just the segment name and now it returns the full relative path.

--- a/cmd/tsdb/main.go
+++ b/cmd/tsdb/main.go
@@ -104,7 +104,6 @@ func (b *writeBenchmark) run() {
 	l = log.With(l, "ts", log.DefaultTimestampUTC, "caller", log.DefaultCaller)
 
 	st, err := tsdb.Open(dir, l, nil, &tsdb.Options{
-		WALFlushInterval:  200 * time.Millisecond,
 		RetentionDuration: 15 * 24 * 60 * 60 * 1000, // 15 days in milliseconds
 		BlockRanges:       tsdb.ExponentialBlockRanges(2*60*60*1000, 5, 3),
 	})

--- a/db.go
+++ b/db.go
@@ -44,7 +44,6 @@ import (
 // DefaultOptions used for the DB. They are sane for setups using
 // millisecond precision timestamps.
 var DefaultOptions = &Options{
-	WALFlushInterval:  5 * time.Second,
 	RetentionDuration: 15 * 24 * 60 * 60 * 1000, // 15 days in milliseconds
 	BlockRanges:       ExponentialBlockRanges(int64(2*time.Hour)/1e6, 3, 5),
 	NoLockfile:        false,
@@ -52,9 +51,6 @@ var DefaultOptions = &Options{
 
 // Options of the DB storage.
 type Options struct {
-	// The interval at which the write ahead log is flushed to disk.
-	WALFlushInterval time.Duration
-
 	// Duration of persisted data to keep.
 	RetentionDuration uint64
 

--- a/wal.go
+++ b/wal.go
@@ -94,27 +94,6 @@ type WAL interface {
 	Close() error
 }
 
-// NopWAL is a WAL that does nothing.
-func NopWAL() WAL {
-	return nopWAL{}
-}
-
-type nopWAL struct{}
-
-func (nopWAL) Read(
-	seriesf func([]RefSeries),
-	samplesf func([]RefSample),
-	deletesf func([]Stone),
-) error {
-	return nil
-}
-func (w nopWAL) Reader() WALReader                     { return w }
-func (nopWAL) LogSeries([]RefSeries) error             { return nil }
-func (nopWAL) LogSamples([]RefSample) error            { return nil }
-func (nopWAL) LogDeletes([]Stone) error                { return nil }
-func (nopWAL) Truncate(int64, func(uint64) bool) error { return nil }
-func (nopWAL) Close() error                            { return nil }
-
 // WALReader reads entries from a WAL.
 type WALReader interface {
 	Read(


### PR DESCRIPTION

The `WALFlushInterval` is not used anywhere in the code base.
The `WAL` is not an interface anymore to save some lookup time so can't use `NopWAL` in the tests. Instead can just pass `nil` as the code checks for that and it is essentially a `noop`.

Signed-off-by: Krasi Georgiev <kgeorgie@redhat.com>