### PR TITLE
remove unused `PrefixMatcher`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## master / unreleased
 
+ - [REMOVED] `PrefixMatcher` is considered unused so was removed.
+
 ## 0.3.0
 
  - [CHANGE] `LastCheckpoint()` used to return just the segment name and now it returns the full relative path.

--- a/labels/selector.go
+++ b/labels/selector.go
@@ -15,7 +15,6 @@ package labels
 
 import (
 	"regexp"
-	"strings"
 )
 
 // Selector holds constraints for matching against a label set.
@@ -104,17 +103,3 @@ func Not(m Matcher) Matcher {
 type PrefixMatcher struct {
 	name, prefix string
 }
-
-// NewPrefixMatcher returns new Matcher for label name matching prefix.
-func NewPrefixMatcher(name, prefix string) Matcher {
-	return &PrefixMatcher{name: name, prefix: prefix}
-}
-
-// Name implements Matcher interface.
-func (m *PrefixMatcher) Name() string { return m.name }
-
-// Prefix returns matching prefix.
-func (m *PrefixMatcher) Prefix() string { return m.prefix }
-
-// Matches implements Matcher interface.
-func (m *PrefixMatcher) Matches(v string) bool { return strings.HasPrefix(v, m.prefix) }

--- a/labels/selector.go
+++ b/labels/selector.go
@@ -98,8 +98,3 @@ func (m *notMatcher) Matches(v string) bool { return !m.Matcher.Matches(v) }
 func Not(m Matcher) Matcher {
 	return &notMatcher{m}
 }
-
-// PrefixMatcher implements Matcher for labels which values matches prefix.
-type PrefixMatcher struct {
-	name, prefix string
-}

--- a/querier.go
+++ b/querier.go
@@ -247,37 +247,6 @@ func PostingsForMatchers(ix IndexReader, ms ...labels.Matcher) (index.Postings, 
 	return ix.SortedPostings(index.Intersect(its...)), nil
 }
 
-// tuplesByPrefix uses binary search to find prefix matches within ts.
-func tuplesByPrefix(m *labels.PrefixMatcher, ts StringTuples) ([]string, error) {
-	var outErr error
-	tslen := ts.Len()
-	i := sort.Search(tslen, func(i int) bool {
-		vs, err := ts.At(i)
-		if err != nil {
-			outErr = fmt.Errorf("Failed to read tuple %d/%d: %v", i, tslen, err)
-			return true
-		}
-		val := vs[0]
-		l := len(m.Prefix())
-		if l > len(vs) {
-			l = len(val)
-		}
-		return val[:l] >= m.Prefix()
-	})
-	if outErr != nil {
-		return nil, outErr
-	}
-	var matches []string
-	for ; i < tslen; i++ {
-		vs, err := ts.At(i)
-		if err != nil || !m.Matches(vs[0]) {
-			return matches, err
-		}
-		matches = append(matches, vs[0])
-	}
-	return matches, nil
-}
-
 func postingsForMatcher(ix IndexReader, m labels.Matcher) (index.Postings, error) {
 	// If the matcher selects an empty value, it selects all the series which don't
 	// have the label name set too. See: https://github.com/prometheus/prometheus/issues/3575
@@ -301,21 +270,13 @@ func postingsForMatcher(ix IndexReader, m labels.Matcher) (index.Postings, error
 	}
 
 	var res []string
-	if pm, ok := m.(*labels.PrefixMatcher); ok {
-		res, err = tuplesByPrefix(pm, tpls)
+	for i := 0; i < tpls.Len(); i++ {
+		vals, err := tpls.At(i)
 		if err != nil {
 			return nil, err
 		}
-
-	} else {
-		for i := 0; i < tpls.Len(); i++ {
-			vals, err := tpls.At(i)
-			if err != nil {
-				return nil, err
-			}
-			if m.Matches(vals[0]) {
-				res = append(res, vals[0])
-			}
+		if m.Matches(vals[0]) {
+			res = append(res, vals[0])
 		}
 	}
 

--- a/querier_test.go
+++ b/querier_test.go
@@ -375,47 +375,6 @@ func TestBlockQuerier(t *testing.T) {
 					},
 				},
 			},
-			{
-				lset: map[string]string{
-					"p": "abcd",
-					"x": "xyz",
-				},
-				chunks: [][]sample{
-					{
-						{1, 2}, {2, 3}, {3, 4},
-					},
-					{
-						{5, 2}, {6, 3}, {7, 4},
-					},
-				},
-			},
-			{
-				lset: map[string]string{
-					"a": "ab",
-					"p": "abce",
-				},
-				chunks: [][]sample{
-					{
-						{1, 1}, {2, 2}, {3, 3},
-					},
-					{
-						{5, 3}, {6, 6},
-					},
-				},
-			},
-			{
-				lset: map[string]string{
-					"p": "xyz",
-				},
-				chunks: [][]sample{
-					{
-						{1, 1}, {2, 2}, {3, 3},
-					},
-					{
-						{4, 4}, {5, 5}, {6, 6},
-					},
-				},
-			},
 		},
 
 		queries: []query{
@@ -452,25 +411,6 @@ func TestBlockQuerier(t *testing.T) {
 						"b": "b",
 					},
 						[]Sample{sample{2, 2}, sample{3, 3}, sample{5, 3}, sample{6, 6}},
-					),
-				}),
-			},
-			{
-				mint: 2,
-				maxt: 6,
-				ms:   []labels.Matcher{labels.NewPrefixMatcher("p", "abc")},
-				exp: newMockSeriesSet([]Series{
-					newSeries(map[string]string{
-						"a": "ab",
-						"p": "abce",
-					},
-						[]Sample{sample{2, 2}, sample{3, 3}, sample{5, 3}, sample{6, 6}},
-					),
-					newSeries(map[string]string{
-						"p": "abcd",
-						"x": "xyz",
-					},
-						[]Sample{sample{2, 3}, sample{3, 4}, sample{5, 2}, sample{6, 3}},
 					),
 				}),
 			},


### PR DESCRIPTION
Brian mentioned that is probably not used by anyone so just a cleanup 

@gouthamve that was one of your firs PR reviews, remember the times :smiley_cat:  !
https://github.com/prometheus/tsdb/pull/111
Signed-off-by: Krasi Georgiev <kgeorgie@redhat.com>