### PR TITLE
Fixs annotation spelling error

### DIFF
--- a/db.go
+++ b/db.go
@@ -184,7 +184,7 @@ func newDBMetrics(db *DB, r prometheus.Registerer) *dbMetrics {
 	})
 	m.startTime = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
 		Name: "prometheus_tsdb_lowest_timestamp",
-		Help: "Lowest timestamp value stored in the database.",
+		Help: "Lowest timestamp value stored in the database. The unit is decided by the library consumer.",
 	}, func() float64 {
 		db.mtx.RLock()
 		defer db.mtx.RUnlock()

--- a/db_test.go
+++ b/db_test.go
@@ -1383,7 +1383,7 @@ func TestDB_LabelNames(t *testing.T) {
 		err = db.compact()
 		testutil.Ok(t, err)
 		// All blocks have same label names, hence check them individually.
-		// No need to aggregrate and check.
+		// No need to aggregate and check.
 		for _, b := range db.Blocks() {
 			blockIndexr, err := b.Index()
 			testutil.Ok(t, err)

--- a/head.go
+++ b/head.go
@@ -572,7 +572,7 @@ func (h *Head) Truncate(mint int64) (err error) {
 }
 
 // initTime initializes a head with the first timestamp. This only needs to be called
-// for a compltely fresh head with an empty WAL.
+// for a completely fresh head with an empty WAL.
 // Returns true if the initialization took an effect.
 func (h *Head) initTime(t int64) (initialized bool) {
 	if !atomic.CompareAndSwapInt64(&h.minTime, math.MaxInt64, t) {

--- a/head.go
+++ b/head.go
@@ -137,13 +137,13 @@ func newHeadMetrics(h *Head, r prometheus.Registerer) *headMetrics {
 	})
 	m.maxTime = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
 		Name: "prometheus_tsdb_head_max_time",
-		Help: "Maximum timestamp of the head block.",
+		Help: "Maximum timestamp of the head block. The unit is decided by the library consumer.",
 	}, func() float64 {
 		return float64(h.MaxTime())
 	})
 	m.minTime = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
 		Name: "prometheus_tsdb_head_min_time",
-		Help: "Minimum time bound of the head block.",
+		Help: "Minimum time bound of the head block. The unit is decided by the library consumer.",
 	}, func() float64 {
 		return float64(h.MinTime())
 	})

--- a/repair.go
+++ b/repair.go
@@ -71,7 +71,7 @@ func repairBadIndexVersion(logger log.Logger, dir string) error {
 		if _, err := io.Copy(repl, broken); err != nil {
 			return wrapErr(err, d)
 		}
-		// Set the 5th byte to 2 to indiciate the correct file format version.
+		// Set the 5th byte to 2 to indicate the correct file format version.
 		if _, err := repl.WriteAt([]byte{2}, 4); err != nil {
 			return wrapErr(err, d)
 		}

--- a/wal.go
+++ b/wal.go
@@ -322,7 +322,7 @@ func (w *SegmentWAL) putBuffer(b *encbuf) {
 }
 
 // Truncate deletes the values prior to mint and the series which the keep function
-// does not indiciate to preserve.
+// does not indicate to preserve.
 func (w *SegmentWAL) Truncate(mint int64, keep func(uint64) bool) error {
 	// The last segment is always active.
 	if len(w.files) < 2 {

--- a/wal_test.go
+++ b/wal_test.go
@@ -436,7 +436,7 @@ func TestWALRestoreCorrupted(t *testing.T) {
 }
 
 func TestMigrateWAL_Empty(t *testing.T) {
-	// The migration proecedure must properly deal with a zero-length segment,
+	// The migration procedure must properly deal with a zero-length segment,
 	// which is valid in the new format.
 	dir, err := ioutil.TempDir("", "walmigrate")
 	testutil.Ok(t, err)


### PR DESCRIPTION
Fix annotation typo "proecedure" to "procedure" in [wal_test.go](https://github.com/prometheus/tsdb/compare/master...JoeWrightss:patch-4?expand=1#diff-7a895460ba897c8893d5bd0110feaaca) at line 439.