### PR TITLE
More efficient Merge implementation.

### DIFF
--- a/index/postings_test.go
+++ b/index/postings_test.go
@@ -233,7 +233,7 @@ func TestMergedPostings(t *testing.T) {
 		a := newListPostings(c.a)
 		b := newListPostings(c.b)
 
-		res, err := ExpandPostings(newMergedPostings(a, b))
+		res, err := ExpandPostings(Merge(a, b))
 		testutil.Ok(t, err)
 		testutil.Equals(t, c.res, res)
 	}
@@ -286,7 +286,7 @@ func TestMergedPostingsSeek(t *testing.T) {
 		a := newListPostings(c.a)
 		b := newListPostings(c.b)
 
-		p := newMergedPostings(a, b)
+		p := Merge(a, b)
 
 		testutil.Equals(t, c.success, p.Seek(c.seek))
 
@@ -546,7 +546,7 @@ func TestIntersectWithMerge(t *testing.T) {
 	// https://github.com/prometheus/prometheus/issues/2616
 	a := newListPostings([]uint64{21, 22, 23, 24, 25, 30})
 
-	b := newMergedPostings(
+	b := Merge(
 		newListPostings([]uint64{10, 20, 30}),
 		newListPostings([]uint64{15, 26, 30}),
 	)


### PR DESCRIPTION
Avoid a tree of merge objects, which can result in
what I suspect is n^2 calls to Seek when using Without.

With 100k metrics, and a regex of ^$ in BenchmarkHeadPostingForMatchers:

Before:
BenchmarkHeadPostingForMatchers-8              1        51633185216 ns/op      29745528 B/op      200357 allocs/op

After:
BenchmarkHeadPostingForMatchers-8             10         108924996 ns/op 25715025 B/op     101748 allocs/op

Signed-off-by: Brian Brazil <brian.brazil@robustperception.io>