### PR TITLE
createPopulatedBlock returns the block dir instead of the block

### DIFF
--- a/block_test.go
+++ b/block_test.go
@@ -78,8 +78,8 @@ func createEmptyBlock(t *testing.T, dir string, meta *BlockMeta) *Block {
 }
 
 // createPopulatedBlock creates a block with nSeries series, filled with
-// samples of the given mint,maxt time range.
-func createPopulatedBlock(tb testing.TB, dir string, nSeries int, mint, maxt int64) *Block {
+// samples of the given mint,maxt time range and returns its dir.
+func createPopulatedBlock(tb testing.TB, dir string, nSeries int, mint, maxt int64) string {
 	head, err := NewHead(nil, nil, nil, 2*60*60*1000)
 	testutil.Ok(tb, err)
 	defer head.Close()
@@ -113,7 +113,5 @@ func createPopulatedBlock(tb testing.TB, dir string, nSeries int, mint, maxt int
 	ulid, err := compactor.Write(dir, head, head.MinTime(), head.MaxTime(), nil)
 	testutil.Ok(tb, err)
 
-	blk, err := OpenBlock(filepath.Join(dir, ulid.String()), nil)
-	testutil.Ok(tb, err)
-	return blk
+	return filepath.Join(dir, ulid.String())
 }

--- a/querier_test.go
+++ b/querier_test.go
@@ -1232,7 +1232,8 @@ func BenchmarkPersistedQueries(b *testing.B) {
 				dir, err := ioutil.TempDir("", "bench_persisted")
 				testutil.Ok(b, err)
 				defer os.RemoveAll(dir)
-				block := createPopulatedBlock(b, dir, nSeries, 1, int64(nSamples))
+				block, err := OpenBlock(createPopulatedBlock(b, dir, nSeries, 1, int64(nSamples)), nil)
+				testutil.Ok(b, err)
 				defer block.Close()
 
 				q, err := NewBlockQuerier(block, block.Meta().MinTime, block.Meta().MaxTime)


### PR DESCRIPTION
It is easy to forget to close the block returned by createPopulatedBlock
which causes failures for windows so instead it returns the block dir
and which can be used by OpenBlock explicitly.

Signed-off-by: Krasi Georgiev <kgeorgie@redhat.com>