### PR TITLE
refactor createBlock to be more generic

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -87,7 +87,7 @@ func TestDB_reloadOrder(t *testing.T) {
 		{MinTime: 100, MaxTime: 110},
 	}
 	for _, m := range metas {
-		createBlock(t, db.Dir(), 1, m.MinTime, m.MaxTime)
+		createBlock(t, db.Dir(), 1, 1, false, false, m.MinTime, m.MaxTime)
 	}
 
 	testutil.Ok(t, db.reload())
@@ -833,7 +833,7 @@ func TestTombstoneCleanFail(t *testing.T) {
 	// totalBlocks should be >=2 so we have enough blocks to trigger compaction failure.
 	totalBlocks := 2
 	for i := 0; i < totalBlocks; i++ {
-		blockDir := createBlock(t, db.Dir(), 0, 0, 0)
+		blockDir := createBlock(t, db.Dir(), 0, 0, false, false, 0, 0)
 		block, err := OpenBlock(blockDir, nil)
 		testutil.Ok(t, err)
 		// Add some some fake tombstones to trigger the compaction.
@@ -877,7 +877,7 @@ func (c *mockCompactorFailing) Write(dest string, b BlockReader, mint, maxt int6
 		return ulid.ULID{}, fmt.Errorf("the compactor already did the maximum allowed blocks so it is time to fail")
 	}
 
-	block, err := OpenBlock(createBlock(c.t, dest, 0, 0, 0), nil)
+	block, err := OpenBlock(createBlock(c.t, dest, 0, 0, false, false, 0, 0), nil)
 	testutil.Ok(c.t, err)
 	testutil.Ok(c.t, block.Close()) // Close block as we won't be using anywhere.
 	c.blocks = append(c.blocks, block)
@@ -1277,7 +1277,7 @@ func TestInitializeHeadTimestamp(t *testing.T) {
 		testutil.Ok(t, err)
 		defer os.RemoveAll(dir)
 
-		createBlock(t, dir, 1, 1000, 2000)
+		createBlock(t, dir, 1, 1, false, false, 1000, 2000)
 
 		db, err := Open(dir, nil, nil, nil)
 		testutil.Ok(t, err)
@@ -1290,7 +1290,7 @@ func TestInitializeHeadTimestamp(t *testing.T) {
 		testutil.Ok(t, err)
 		defer os.RemoveAll(dir)
 
-		createBlock(t, dir, 1, 1000, 6000)
+		createBlock(t, dir, 1, 1, false, false, 1000, 6000)
 
 		testutil.Ok(t, os.MkdirAll(path.Join(dir, "wal"), 0777))
 		w, err := wal.New(nil, nil, path.Join(dir, "wal"))
@@ -1477,7 +1477,7 @@ func TestBlockRanges(t *testing.T) {
 	// Test that the compactor doesn't create overlapping blocks
 	// when a non standard block already exists.
 	firstBlockMaxT := int64(3)
-	createBlock(t, dir, 1, 0, firstBlockMaxT)
+	createBlock(t, dir, 1, 1, false, false, 0, firstBlockMaxT)
 	db, err := Open(dir, logger, nil, DefaultOptions)
 	if err != nil {
 		t.Fatalf("Opening test storage failed: %s", err)
@@ -1526,7 +1526,7 @@ func TestBlockRanges(t *testing.T) {
 	testutil.Ok(t, db.Close())
 
 	thirdBlockMaxt := secondBlockMaxt + 2
-	createBlock(t, dir, 1, secondBlockMaxt+1, thirdBlockMaxt)
+	createBlock(t, dir, 1, 1, false, false, secondBlockMaxt+1, thirdBlockMaxt)
 
 	db, err = Open(dir, logger, nil, DefaultOptions)
 	if err != nil {

--- a/index/index_test.go
+++ b/index/index_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/prometheus/tsdb/chunks"
 	"github.com/prometheus/tsdb/labels"
 	"github.com/prometheus/tsdb/testutil"
+	"github.com/prometheus/tsdb/tsdbutil"
 )
 
 type series struct {
@@ -237,9 +238,7 @@ func TestPersistence_index_e2e(t *testing.T) {
 	testutil.Ok(t, err)
 	defer os.RemoveAll(dir)
 
-	lbls, err := labels.ReadLabels(filepath.Join("..", "testdata", "20kseries.json"), 20000)
-	testutil.Ok(t, err)
-
+	lbls := tsdbutil.GenSeries(20000, 10, true, false)
 	// Sort labels as the index writer expects series in sorted order.
 	sort.Sort(labels.Slice(lbls))
 

--- a/querier_test.go
+++ b/querier_test.go
@@ -1232,7 +1232,7 @@ func BenchmarkPersistedQueries(b *testing.B) {
 				dir, err := ioutil.TempDir("", "bench_persisted")
 				testutil.Ok(b, err)
 				defer os.RemoveAll(dir)
-				block, err := OpenBlock(createBlock(b, dir, nSeries, 1, int64(nSamples)), nil)
+				block, err := OpenBlock(createBlock(b, dir, nSeries, 10, false, false, 1, int64(nSamples)), nil)
 				testutil.Ok(b, err)
 				defer block.Close()
 

--- a/tsdbutil/series.go
+++ b/tsdbutil/series.go
@@ -1,0 +1,89 @@
+// Copyright 2013 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tsdbutil
+
+import (
+	"math/rand"
+	"time"
+
+	"github.com/prometheus/tsdb/labels"
+)
+
+// GenSeries generates series with a given number of labels and values.
+func GenSeries(totalSeries int, labelCount int, cardinality, churn bool) []labels.Labels {
+	series := make([]labels.Labels, totalSeries)
+	if totalSeries == 0 || labelCount == 0 {
+		return nil
+	}
+
+	labelNames := make([]string, labelCount)
+	labelValues := make([]string, labelCount)
+
+	// Generate all label names and values.
+	for v := 0; v < labelCount; v++ {
+		labelNames[v] = RandString()
+		if !cardinality {
+			labelValues[v] = RandString()
+		}
+	}
+
+	for s := 0; s < totalSeries; s++ {
+		lbs := labels.Labels{}
+		lbsC := labelCount
+		if churn {
+			rand.Seed(time.Now().UnixNano())
+			lbsC = rand.Intn(labelCount) + 1 // We don't want 0.
+		}
+		for i := 0; i < lbsC; i++ {
+			l := labels.Label{
+				Name:  labelNames[i],
+				Value: labelValues[i],
+			}
+			if l.Value == "" {
+				l.Value = RandString()
+			}
+			lbs = append(lbs, l)
+		}
+		series[s] = lbs
+	}
+	return series
+}
+
+const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+const (
+	letterIdxBits = 6                    // 6 bits to represent a letter index
+	letterIdxMask = 1<<letterIdxBits - 1 // All 1-bits, as many as letterIdxBits
+	letterIdxMax  = 63 / letterIdxBits   // # of letter indices fitting in 63 bits
+)
+
+// RandString generates random string.
+func RandString() string {
+	maxLength := int32(50)
+	length := rand.Int31n(maxLength)
+	b := make([]byte, length+1)
+	// A rand.Int63() generates 63 random bits, enough for letterIdxMax characters!
+	for i, cache, remain := length, rand.Int63(), letterIdxMax; i >= 0; {
+		if remain == 0 {
+			cache, remain = rand.Int63(), letterIdxMax
+		}
+		if idx := int(cache & letterIdxMask); idx < len(letterBytes) {
+			b[i] = letterBytes[idx]
+			i--
+		}
+		cache >>= letterIdxBits
+		remain--
+	}
+
+	return string(b)
+}


### PR DESCRIPTION
It allows generating a block with unlimited series count with or without
high cardinality and churn.

Signed-off-by: Krasi Georgiev <kgeorgie@redhat.com>