### PR TITLE
Remove pointer indirection on chunk bstream

### DIFF
--- a/chunkenc/chunk.go
+++ b/chunkenc/chunk.go
@@ -52,7 +52,7 @@ type Chunk interface {
 func FromData(e Encoding, d []byte) (Chunk, error) {
 	switch e {
 	case EncXOR:
-		return &XORChunk{b: &bstream{count: 0, stream: d}}, nil
+		return &XORChunk{b: bstream{count: 0, stream: d}}, nil
 	}
 	return nil, fmt.Errorf("unknown chunk encoding: %d", e)
 }
@@ -94,7 +94,7 @@ func NewPool() Pool {
 	return &pool{
 		xor: sync.Pool{
 			New: func() interface{} {
-				return &XORChunk{b: &bstream{}}
+				return &XORChunk{b: bstream{}}
 			},
 		},
 	}

--- a/chunkenc/xor.go
+++ b/chunkenc/xor.go
@@ -51,13 +51,13 @@ import (
 
 // XORChunk holds XOR encoded sample data.
 type XORChunk struct {
-	b *bstream
+	b bstream
 }
 
 // NewXORChunk returns a new chunk with XOR encoding of the given size.
 func NewXORChunk() *XORChunk {
 	b := make([]byte, 2, 128)
-	return &XORChunk{b: &bstream{stream: b, count: 0}}
+	return &XORChunk{b: bstream{stream: b, count: 0}}
 }
 
 // Encoding returns the encoding type.
@@ -89,7 +89,7 @@ func (c *XORChunk) Appender() (Appender, error) {
 	}
 
 	a := &xorAppender{
-		b:        c.b,
+		b:        &c.b,
 		t:        it.t,
 		v:        it.val,
 		tDelta:   it.tDelta,


### PR DESCRIPTION
It isn't necessary since the member is never changed after initialization.

Saves 8 bytes per chunk, and a bit of time following the pointer and garbage-collecting the extra object.