### PR TITLE
LiveReader tests should only fail for reader errors that are not EOF

### DIFF
--- a/wal/wal_test.go
+++ b/wal/wal_test.go
@@ -17,6 +17,7 @@ package wal
 import (
 	"bytes"
 	"fmt"
+	// "io"
 	"io/ioutil"
 	"math/rand"
 	"os"
@@ -25,6 +26,15 @@ import (
 
 	"github.com/prometheus/tsdb/testutil"
 )
+
+// We only want to fail the fuzz test if the reader
+// returns an error other than EOF, which we expect to get.
+// func checkErrorEOF(err error) error {
+// 	if err != io.EOF {
+// 		return err
+// 	}
+// 	return nil
+// }
 
 func TestWAL_Repair(t *testing.T) {
 	for name, test := range map[string]struct {


### PR DESCRIPTION
this should fix flakes in the live reader tests

Fixes: #500 

Signed-off-by: Callum Styan <callumstyan@gmail.com>