### PR TITLE
optimize createBlock - generate the labels map only once.

### DIFF
--- a/block_test.go
+++ b/block_test.go
@@ -102,11 +102,12 @@ func genSeries(totalSeries, labelCount int, mint, maxt int64) []Series {
 	}
 	series := make([]Series, totalSeries)
 
+	lbls := make(map[string]string, labelCount)
+	for len(lbls) < labelCount {
+		lbls[randString()] = randString()
+	}
 	for i := 0; i < totalSeries; i++ {
-		lbls := make(map[string]string, labelCount)
-		for len(lbls) < labelCount {
-			lbls[randString()] = randString()
-		}
+
 		samples := make([]tsdbutil.Sample, 0, maxt-mint+1)
 		for t := mint; t <= maxt; t++ {
 			samples = append(samples, sample{t: t, v: rand.Float64()})

--- a/block_test.go
+++ b/block_test.go
@@ -105,7 +105,7 @@ func genSeries(totalSeries, labelCount int, mint, maxt int64) []Series {
 	lbls := make(map[string]string, labelCount)
 	var lastKey string
 	for len(lbls) < labelCount {
-		lastKey := randString()
+		lastKey = randString()
 		lbls[lastKey] = randString()
 	}
 	for i := 0; i < totalSeries; i++ {

--- a/block_test.go
+++ b/block_test.go
@@ -103,8 +103,10 @@ func genSeries(totalSeries, labelCount int, mint, maxt int64) []Series {
 	series := make([]Series, totalSeries)
 
 	lbls := make(map[string]string, labelCount)
+	var lastKey string
 	for len(lbls) < labelCount {
-		lbls[randString()] = randString()
+		lastKey := randString()
+		lbls[lastKey] = randString()
 	}
 	for i := 0; i < totalSeries; i++ {
 
@@ -112,6 +114,7 @@ func genSeries(totalSeries, labelCount int, mint, maxt int64) []Series {
 		for t := mint; t <= maxt; t++ {
 			samples = append(samples, sample{t: t, v: rand.Float64()})
 		}
+		lbls[lastKey] = randString() // Add at least one unique label to make these different series.
 		series[i] = newSeries(lbls, samples)
 	}
 


### PR DESCRIPTION
This reduces the CPU time in half.

cc @codesome 

Signed-off-by: Krasi Georgiev <kgeorgie@redhat.com>