### PR TITLE
compact: Fixed populateBlock to adjust out ouf boundary chunks automatically.

### DIFF
--- a/compact_test.go
+++ b/compact_test.go
@@ -15,7 +15,6 @@ package tsdb
 
 import (
 	"io/ioutil"
-	"math"
 	"os"
 	"path/filepath"
 	"testing"
@@ -436,35 +435,49 @@ func TestCompaction_populateBlock(t *testing.T) {
 					},
 				},
 			},
+			compactMaxTime: 10,
 		},
 		{
 			title: "Populate from single block. We expect the same samples at the output.",
 			inputSeriesSamples: [][]seriesSamples{
 				{
 					{
-						lset:   map[string]string{"a": "b"},
-						chunks: [][]sample{{{t: 0}, {t: 10}}, {{t: 11}, {t: 20}}},
+						lset: map[string]string{"a": "b"},
+						chunks: [][]sample{
+							{{t: 0}, {t: 10}},
+							{{t: 11}, {t: 20}},
+						},
 					},
 				},
 			},
 			expSeriesSamples: []seriesSamples{
 				{
-					lset:   map[string]string{"a": "b"},
-					chunks: [][]sample{{{t: 0}, {t: 10}}, {{t: 11}, {t: 20}}},
+					lset: map[string]string{"a": "b"},
+					chunks: [][]sample{
+						{{t: 0}, {t: 10}},
+						{{t: 11}, {t: 20}},
+					},
 				},
 			},
+			compactMaxTime: 30,
 		},
 		{
 			title: "Populate from two blocks.",
 			inputSeriesSamples: [][]seriesSamples{
 				{
 					{
-						lset:   map[string]string{"a": "b"},
-						chunks: [][]sample{{{t: 0}, {t: 10}}, {{t: 11}, {t: 20}}},
+						lset: map[string]string{"a": "b"},
+						chunks: [][]sample{
+							{{t: 0}, {t: 10}},
+							{{t: 11}, {t: 20}},
+						},
 					},
 					{
-						lset:   map[string]string{"a": "c"},
-						chunks: [][]sample{{{t: 1}, {t: 9}}, {{t: 10}, {t: 19}}},
+						lset: map[string]string{"a": "c"},
+						chunks: [][]sample{
+							{{t: 1}, {t: 9}},
+							{{t: 10}, {t: 19}},
+						},
 					},
 					{
 						// no-chunk series should be dropped.
@@ -482,14 +495,23 @@ func TestCompaction_populateBlock(t *testing.T) {
 					},
 				},
 			},
+			compactMaxTime: 50,
 			expSeriesSamples: []seriesSamples{
 				{
-					lset:   map[string]string{"a": "b"},
-					chunks: [][]sample{{{t: 0}, {t: 10}}, {{t: 11}, {t: 20}}, {{t: 21}, {t: 30}}},
+					lset: map[string]string{"a": "b"},
+					chunks: [][]sample{
+						{{t: 0}, {t: 10}},
+						{{t: 11}, {t: 20}},
+						{{t: 21}, {t: 30}},
+					},
 				},
 				{
-					lset:   map[string]string{"a": "c"},
-					chunks: [][]sample{{{t: 1}, {t: 9}}, {{t: 10}, {t: 19}}, {{t: 40}, {t: 45}}},
+					lset: map[string]string{"a": "c"},
+					chunks: [][]sample{
+						{{t: 1}, {t: 9}},
+						{{t: 10}, {t: 19}},
+						{{t: 40}, {t: 45}},
+					},
 				},
 			},
 		},
@@ -508,23 +530,38 @@ func TestCompaction_populateBlock(t *testing.T) {
 				},
 				{
 					{
-						lset:   map[string]string{"a": "b"},
-						chunks: [][]sample{{{t: 0}, {t: 10}}, {{t: 11}, {t: 20}}},
+						lset: map[string]string{"a": "b"},
+						chunks: [][]sample{
+							{{t: 0}, {t: 10}},
+							{{t: 11}, {t: 20}},
+						},
 					},
 					{
-						lset:   map[string]string{"a": "c"},
-						chunks: [][]sample{{{t: 1}, {t: 9}}, {{t: 10}, {t: 19}}},
+						lset: map[string]string{"a": "c"},
+						chunks: [][]sample{
+							{{t: 1}, {t: 9}},
+							{{t: 10}, {t: 19}},
+						},
 					},
 				},
 			},
+			compactMaxTime: 50,
 			expSeriesSamples: []seriesSamples{
 				{
-					lset:   map[string]string{"a": "b"},
-					chunks: [][]sample{{{t: 21}, {t: 30}}, {{t: 0}, {t: 10}}, {{t: 11}, {t: 20}}},
+					lset: map[string]string{"a": "b"},
+					chunks: [][]sample{
+						{{t: 21}, {t: 30}},
+						{{t: 0}, {t: 10}},
+						{{t: 11}, {t: 20}},
+					},
 				},
 				{
-					lset:   map[string]string{"a": "c"},
-					chunks: [][]sample{{{t: 40}, {t: 45}}, {{t: 1}, {t: 9}}, {{t: 10}, {t: 19}}},
+					lset: map[string]string{"a": "c"},
+					chunks: [][]sample{
+						{{t: 40}, {t: 45}},
+						{{t: 1}, {t: 9}},
+						{{t: 10}, {t: 19}},
+					},
 				},
 			},
 		},
@@ -560,6 +597,7 @@ func TestCompaction_populateBlock(t *testing.T) {
 					},
 				},
 			},
+			compactMaxTime: 10,
 			expSeriesSamples: []seriesSamples{
 				{
 					lset:   map[string]string{"a": "1"},
@@ -578,40 +616,90 @@ func TestCompaction_populateBlock(t *testing.T) {
 					chunks: [][]sample{{{t: 5}, {t: 7}}},
 				},
 				{
-					lset:   map[string]string{"a": "same"},
-					chunks: [][]sample{{{t: 1}, {t: 4}}, {{t: 5}, {t: 8}}},
+					lset: map[string]string{"a": "same"},
+					chunks: [][]sample{
+						{{t: 1}, {t: 4}},
+						{{t: 5}, {t: 8}},
+					},
 				},
 			},
 		},
 		{
 			// This should not happened because head block is making sure the chunks are not crossing block boundaries.
-			title: "Populate from single block containing chunk outside of compact meta time range.",
+			title: "Populate from single block containing chunk that starts before compact meta time range.",
 			inputSeriesSamples: [][]seriesSamples{
 				{
 					{
-						lset:   map[string]string{"a": "b"},
-						chunks: [][]sample{{{t: 1}, {t: 2}}, {{t: 10}, {t: 30}}},
+						lset: map[string]string{"a": "b"},
+						chunks: [][]sample{
+							{{t: 1}, {t: 2}},
+							{{t: 10}, {t: 30}},
+						},
 					},
 				},
 			},
-			compactMinTime: 0,
-			compactMaxTime: 20,
-			expErr:         errors.New("found chunk with minTime: 10 maxTime: 30 outside of compacted minTime: 0 maxTime: 20"),
+			compactMinTime: 2,
+			compactMaxTime: 30,
+			expErr:         errors.New("found chunk with minTime: 1 maxTime: 2 outside of compacted minTime: 2 maxTime: 30"),
 		},
 		{
-			// Introduced by https://github.com/prometheus/tsdb/issues/347.
-			title: "Populate from single block containing extra chunk",
+			title: "Populate from single block containing one chunk partially, one completely after of compact meta time range.",
 			inputSeriesSamples: [][]seriesSamples{
 				{
 					{
-						lset:   map[string]string{"a": "issue347"},
-						chunks: [][]sample{{{t: 1}, {t: 2}}, {{t: 10}, {t: 20}}},
+						// Includes chunk partially outside.
+						lset: map[string]string{"a": "b"},
+						chunks: [][]sample{
+							{{t: 1}, {t: 2}},
+							{{t: 10}, {t: 20}}, {{t: 21}, {t: 30}},
+						},
+					},
+					{
+						// Includes chunk completely outside.
+						// Regression test against https://github.com/prometheus/tsdb/issues/347.
+						lset: map[string]string{"a": "c"},
+						chunks: [][]sample{
+							{{t: 1}, {t: 2}},
+							{{t: 21}, {t: 30}}, // Not sorted order, to double check.
+							{{t: 10}, {t: 20}},
+						},
+					},
+					{
+						// Includes chunk completely outside.
+						// Regression test against https://github.com/prometheus/tsdb/issues/347.
+						lset: map[string]string{"a": "d"},
+						chunks: [][]sample{
+							{{t: 1}, {t: 2}},
+							{{t: 10}, {t: 20}},
+							{{t: 21}, {t: 30}},
+						},
 					},
 				},
 			},
-			compactMinTime: 0,
-			compactMaxTime: 10,
-			expErr:         errors.New("found chunk with minTime: 10 maxTime: 20 outside of compacted minTime: 0 maxTime: 10"),
+			compactMaxTime: 20,
+			expSeriesSamples: []seriesSamples{
+				{
+					lset: map[string]string{"a": "b"},
+					chunks: [][]sample{
+						{{t: 1}, {t: 2}},
+						{{t: 10}, {t: 20}},
+					},
+				},
+				{
+					lset: map[string]string{"a": "c"},
+					chunks: [][]sample{
+						{{t: 1}, {t: 2}},
+						{{t: 10}, {t: 20}},
+					},
+				},
+				{
+					lset: map[string]string{"a": "d"},
+					chunks: [][]sample{
+						{{t: 1}, {t: 2}},
+						{{t: 10}, {t: 20}},
+					},
+				},
+			},
 		},
 		{
 			// No special deduplication expected.
@@ -619,8 +707,11 @@ func TestCompaction_populateBlock(t *testing.T) {
 			inputSeriesSamples: [][]seriesSamples{
 				{
 					{
-						lset:   map[string]string{"a": "b"},
-						chunks: [][]sample{{{t: 1}, {t: 2}}, {{t: 10}, {t: 20}}},
+						lset: map[string]string{"a": "b"},
+						chunks: [][]sample{
+							{{t: 1}, {t: 2}},
+							{{t: 10}, {t: 20}},
+						},
 					},
 				},
 				{
@@ -630,10 +721,15 @@ func TestCompaction_populateBlock(t *testing.T) {
 					},
 				},
 			},
+			compactMaxTime: 20,
 			expSeriesSamples: []seriesSamples{
 				{
-					lset:   map[string]string{"a": "b"},
-					chunks: [][]sample{{{t: 1}, {t: 2}}, {{t: 10}, {t: 20}}, {{t: 10}, {t: 20}}},
+					lset: map[string]string{"a": "b"},
+					chunks: [][]sample{
+						{{t: 1}, {t: 2}},
+						{{t: 10}, {t: 20}},
+						{{t: 10}, {t: 20}},
+					},
 				},
 			},
 		},
@@ -650,23 +746,14 @@ func TestCompaction_populateBlock(t *testing.T) {
 			c, err := NewLeveledCompactor(nil, nil, []int64{0}, nil)
 			testutil.Ok(t, err)
 
-			meta := &BlockMeta{
-				MinTime: tc.compactMinTime,
-				MaxTime: tc.compactMaxTime,
-			}
-			if meta.MaxTime == 0 {
-				meta.MaxTime = math.MaxInt64
-			}
-
 			iw := &mockIndexWriter{}
-			err = c.populateBlock(blocks, meta, iw, nopChunkWriter{})
+			stats, err := c.populateBlock(blocks, tc.compactMinTime, tc.compactMaxTime, iw, nopChunkWriter{})
 			if tc.expErr != nil {
 				testutil.NotOk(t, err)
 				testutil.Equals(t, tc.expErr.Error(), err.Error())
 				return
 			}
 			testutil.Ok(t, err)
-
 			testutil.Equals(t, tc.expSeriesSamples, iw.series)
 
 			// Check if stats are calculated properly.
@@ -679,7 +766,7 @@ func TestCompaction_populateBlock(t *testing.T) {
 					s.NumSamples += uint64(len(chk))
 				}
 			}
-			testutil.Equals(t, s, meta.Stats)
+			testutil.Equals(t, s, stats)
 		}); !ok {
 			return
 		}


### PR DESCRIPTION
Fixes https://github.com/prometheus/prometheus/issues/5105

This is seems to be in the case when you do snapshot and it will invoke `write.Compact` for head
block with certain MaxTime being time.Now in the moment of invoke. During compaction
head block's chunks can be appended anytime resulting in chunks being out max Time.

Changes:
* For block write: 
    * If chunk is partially outside max time, remove leftovers
    * If chunk is completely outside skip it.
    * If chunk is before min time - error out, we don't have use case for this.
* Improvement comments for compactor write API. We aim to guarantee block chunks being
within requested min and max time.
* Added test cases
* Avoided returning via argument if not needed (meta stats)
* Handled error from reader closers in populate Block. For now they are logged as error level.
(We should not block write if we cannot close reader I guess, but we have to be aware at least)

Just to double check: Blocks has (minTime, maxTime> chunks right? Where was documentation for this?
I remember we wanted to note down this somewhere (:

Signed-off-by: Bartek Plotka <bwplotka@gmail.com>