### PR TITLE
clarify which segments are deleted when we find a corrupted segment

### DIFF
--- a/wal/wal.go
+++ b/wal/wal.go
@@ -296,7 +296,7 @@ func (w *WAL) Repair(origErr error) error {
 	if err != nil {
 		return errors.Wrap(err, "list segments")
 	}
-	level.Warn(w.logger).Log("msg", "deleting all segments behind corruption", "segment", cerr.Segment)
+	level.Warn(w.logger).Log("msg", "deleting all segments newer than corrupted segment", "segment", cerr.Segment)
 
 	for _, s := range segs {
 		if w.segment.i == s.index {


### PR DESCRIPTION
The previous version of this log line can be misinterpreted as "segments before corruption" as in older segments not newer segments.

`level=warn ts=2019-02-13T17:09:48.066786461Z caller=wal.go:299 component=tsdb msg="deleting all segments behind corruption" segment=6142`

Signed-off-by: Callum Styan <callumstyan@gmail.com>