### PR TITLE
Test to corrupt segments mid-WAL, repair and check we can read the correct number of records.

### DIFF
--- a/testutil/logging.go
+++ b/testutil/logging.go
@@ -10,10 +10,12 @@ type logger struct {
 	t *testing.T
 }
 
+// NewLogger returns a gokit compatible Logger which calls t.Log.
 func NewLogger(t *testing.T) log.Logger {
 	return logger{t: t}
 }
 
+// Log implements log.Logger.
 func (t logger) Log(keyvals ...interface{}) error {
 	t.t.Log(keyvals...)
 	return nil

--- a/testutil/logging.go
+++ b/testutil/logging.go
@@ -1,3 +1,16 @@
+// Copyright 2019 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package testutil
 
 import (

--- a/testutil/logging.go
+++ b/testutil/logging.go
@@ -1,0 +1,20 @@
+package testutil
+
+import (
+	"testing"
+
+	"github.com/go-kit/kit/log"
+)
+
+type logger struct {
+	t *testing.T
+}
+
+func NewLogger(t *testing.T) log.Logger {
+	return logger{t: t}
+}
+
+func (t logger) Log(keyvals ...interface{}) error {
+	t.t.Log(keyvals...)
+	return nil
+}

--- a/wal/wal.go
+++ b/wal/wal.go
@@ -706,9 +706,7 @@ func (r *segmentBufReader) Close() (err error) {
 	return err
 }
 
-// Read implements io.Reader, expect that we occasionally return err=nil
-// when n != len(b), which violates the inteface.  Only use this with
-// io.ReadFull.
+// Read implements io.Reader.
 func (r *segmentBufReader) Read(b []byte) (n int, err error) {
 	n, err = r.buf.Read(b)
 	r.off += n

--- a/wal/wal_test.go
+++ b/wal/wal_test.go
@@ -560,7 +560,7 @@ func TestCorruptAndCarryOn(t *testing.T) {
 	)
 
 	// Produce a WAL with a two segments of 3 pages with 3 records each,
-	// so when we truncate the file we guaranteed to split a record.
+	// so when we truncate the file we're guaranteed to split a record.
 	{
 		w, err := NewSize(logger, nil, dir, segmentSize)
 		testutil.Ok(t, err)
@@ -597,7 +597,8 @@ func TestCorruptAndCarryOn(t *testing.T) {
 		}
 	}
 
-	// Truncate the first file, splitting the middle record.
+	// Truncate the first file, splitting the middle record in the second
+	// page in half, leaving 4 valid records.
 	{
 		f, err := os.OpenFile(filepath.Join(dir, fmt.Sprintf("%08d", 0)), os.O_RDWR, 0666)
 		testutil.Ok(t, err)

--- a/wal/wal_test.go
+++ b/wal/wal_test.go
@@ -548,6 +548,8 @@ func TestWAL_Repair(t *testing.T) {
 	}
 }
 
+// TestCorruptAndCarryOn writes a multi-segment WAL; corrupts the first segment
+// and then write to write more records to the WAL.
 func TestCorruptAndCarryOn(t *testing.T) {
 	dir, err := ioutil.TempDir("", "wal_repair")
 	testutil.Ok(t, err)

--- a/wal/wal_test.go
+++ b/wal/wal_test.go
@@ -548,8 +548,9 @@ func TestWAL_Repair(t *testing.T) {
 	}
 }
 
-// TestCorruptAndCarryOn writes a multi-segment WAL; corrupts the first segment
-// and then write to write more records to the WAL.
+// TestCorruptAndCarryOn writes a multi-segment WAL; corrupts the first segment and
+// ensures that an error during reading that segment are correctly repaired before
+// moving to write more records to the WAL.
 func TestCorruptAndCarryOn(t *testing.T) {
 	dir, err := ioutil.TempDir("", "wal_repair")
 	testutil.Ok(t, err)


### PR DESCRIPTION
The test fails against master, as the underlying segmentReader has already moved on to the next segment.

Also included - the fix.  Make the segmentReader pad short segments with zeros, and only advance to next segment on the call to `Read` _after_ completely consuming this one; previously it would increment `curr` on the call to `Read` which failed, causing the returns `CorruptionErr` to reference the wrong segment.

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>