### PR TITLE
[bug] didn't update 'last' variable in chunks.MergeOverlappingChunks()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## master / unreleased
+  - [BUGFIX] Update `last` after appending a non-overlapping chunk in `chunks.MergeOverlappingChunks`. [#539](https://github.com/prometheus/tsdb/pull/539)
 
 ## 0.6.0
   - [CHANGE] `AllowOverlappingBlock` is now `AllowOverlappingBlocks`.
-  - [BUGFIX] Update `last` after appending a non-overlapping chunk in `chunks.MergeOverlappingChunks`. [#539](https://github.com/prometheus/tsdb/pull/539)
 
 ## 0.5.0
  - [FEATURE] Time-ovelapping blocks are now allowed. [#370](https://github.com/prometheus/tsdb/pull/370)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.6.0
   - [CHANGE] `AllowOverlappingBlock` is now `AllowOverlappingBlocks`.
+  - [BUGFIX] Update `last` after appending a non-overlapping chunk in `chunks.MergeOverlappingChunks`. [#539](https://github.com/prometheus/tsdb/pull/539)
 
 ## 0.5.0
  - [FEATURE] Time-ovelapping blocks are now allowed. [#370](https://github.com/prometheus/tsdb/pull/370)

--- a/chunks/chunks.go
+++ b/chunks/chunks.go
@@ -213,6 +213,7 @@ func MergeOverlappingChunks(chks []Meta) ([]Meta, error) {
 		// So never overlaps with newChks[last-1] or anything before that.
 		if c.MinTime > newChks[last].MaxTime {
 			newChks = append(newChks, c)
+			last += 1
 			continue
 		}
 		nc := &newChks[last]

--- a/compact_test.go
+++ b/compact_test.go
@@ -654,7 +654,7 @@ func TestCompaction_populateBlock(t *testing.T) {
 		},
 		{
 			// Deduplication expected.
-			// Introduced by https://github.com/prometheus/tsdb/pull/539.
+			// Introduced by pull/370 and pull/539.
 			title: "Populate from two blocks containing duplicated chunk.",
 			inputSeriesSamples: [][]seriesSamples{
 				{

--- a/compact_test.go
+++ b/compact_test.go
@@ -653,7 +653,8 @@ func TestCompaction_populateBlock(t *testing.T) {
 			expErr:         errors.New("found chunk with minTime: 10 maxTime: 20 outside of compacted minTime: 0 maxTime: 10"),
 		},
 		{
-			// No special deduplication expected.
+			// Deduplication expected.
+			// Introduced by https://github.com/prometheus/tsdb/pull/539.
 			title: "Populate from two blocks containing duplicated chunk.",
 			inputSeriesSamples: [][]seriesSamples{
 				{
@@ -672,7 +673,7 @@ func TestCompaction_populateBlock(t *testing.T) {
 			expSeriesSamples: []seriesSamples{
 				{
 					lset:   map[string]string{"a": "b"},
-					chunks: [][]sample{{{t: 1}, {t: 2}}, {{t: 10}, {t: 20}}, {{t: 10}, {t: 20}}},
+					chunks: [][]sample{{{t: 1}, {t: 2}}, {{t: 10}, {t: 20}}},
 				},
 			},
 		},

--- a/compact_test.go
+++ b/compact_test.go
@@ -677,7 +677,7 @@ func TestCompaction_populateBlock(t *testing.T) {
 			},
 		},
 		{
-			// Introduced by 
+			// Introduced by https://github.com/prometheus/tsdb/pull/539.
 			title: "Populate from three blocks that the last two are overlapping.",
 			inputSeriesSamples: [][]seriesSamples{
 				{

--- a/compact_test.go
+++ b/compact_test.go
@@ -676,6 +676,52 @@ func TestCompaction_populateBlock(t *testing.T) {
 				},
 			},
 		},
+		{
+			// Introduced by 
+			title: "Populate from three blocks that the last two are overlapping.",
+			inputSeriesSamples: [][]seriesSamples{
+				{
+					{
+						lset:   map[string]string{"before": "fix"},
+						chunks: [][]sample{{{t: 0}, {t: 10}, {t: 11}, {t: 20}}},
+					},
+					{
+						lset:   map[string]string{"after": "fix"},
+						chunks: [][]sample{{{t: 0}, {t: 10}, {t: 11}, {t: 20}}},
+					},
+				},
+				{
+					{
+						lset:   map[string]string{"before": "fix"},
+						chunks: [][]sample{{{t: 19}, {t: 30}}},
+					},
+					{
+						lset:   map[string]string{"after": "fix"},
+						chunks: [][]sample{{{t: 21}, {t: 30}}},
+					},
+				},
+				{
+					{
+						lset:   map[string]string{"before": "fix"},
+						chunks: [][]sample{{{t: 27}, {t: 35}}},
+					},
+					{
+						lset:   map[string]string{"after": "fix"},
+						chunks: [][]sample{{{t: 27}, {t: 35}}},
+					},
+				},
+			},
+			expSeriesSamples: []seriesSamples{
+				{
+					lset:   map[string]string{"after": "fix"},
+					chunks: [][]sample{{{t: 0}, {t: 10}, {t: 11}, {t: 20}}, {{t: 21}, {t: 27}, {t: 30}, {t: 35}}},
+				},
+				{
+					lset:   map[string]string{"before": "fix"},
+					chunks: [][]sample{{{t: 0}, {t: 10}, {t: 11}, {t: 19}, {t: 20}, {t: 27}, {t: 30}, {t: 35}}},
+				},
+			},
+		},
 	}
 
 	for _, tc := range populateBlocksCases {


### PR DESCRIPTION
1. Update 'last' variable after appending a chunk.
2. I add test case for it. The blocks of labels ("before", "fix") are overlapping together and they can pass in the original codes. The blocks of labels ("after", "fix") are overlapping only for the last two blocks and cannot pass in the original codes.