### PR TITLE
Remove FromData function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## master / unreleased
+ - [REMOVED] `FromData` is considered unused so was removed.
 
 ## 0.6.1
   - [BUGFIX] Update `last` after appending a non-overlapping chunk in `chunks.MergeOverlappingChunks`. [#539](https://github.com/prometheus/tsdb/pull/539)

--- a/chunkenc/chunk.go
+++ b/chunkenc/chunk.go
@@ -14,7 +14,6 @@
 package chunkenc
 
 import (
-	"fmt"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -46,15 +45,6 @@ type Chunk interface {
 	Appender() (Appender, error)
 	Iterator() Iterator
 	NumSamples() int
-}
-
-// FromData returns a chunk from a byte slice of chunk data.
-func FromData(e Encoding, d []byte) (Chunk, error) {
-	switch e {
-	case EncXOR:
-		return &XORChunk{b: bstream{count: 0, stream: d}}, nil
-	}
-	return nil, fmt.Errorf("unknown chunk encoding: %d", e)
 }
 
 // Appender adds sample pairs to a chunk.


### PR DESCRIPTION
The role of `FromData`   function has been replaced by `pool.Get`.

Related PR: #118   
https://github.com/prometheus/tsdb/pull/118/files#diff-5047d434b918cce51937ad6204d8afb0L358