### PR TITLE
Remove unused NewReader function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## master / unreleased
+ - [REMOVED] `chunks.NewReader` is removed as it wasn't used anywhere.
  - [REMOVED] `FromData` is considered unused so was removed.
 
 ## 0.6.1

--- a/chunks/chunks.go
+++ b/chunks/chunks.go
@@ -386,14 +386,6 @@ func newReader(bs []ByteSlice, cs []io.Closer, pool chunkenc.Pool) (*Reader, err
 	return &cr, nil
 }
 
-// NewReader returns a new chunk reader against the given byte slices.
-func NewReader(bs []ByteSlice, pool chunkenc.Pool) (*Reader, error) {
-	if pool == nil {
-		pool = chunkenc.NewPool()
-	}
-	return newReader(bs, nil, pool)
-}
-
 // NewDirReader returns a new Reader against sequentially numbered files in the
 // given directory.
 func NewDirReader(dir string, pool chunkenc.Pool) (*Reader, error) {


### PR DESCRIPTION
The `NewReader` function is not used anywhere.
https://github.com/prometheus/tsdb/blob/719b57db44f5e5dbad7d813a5645c222c3ba7647/chunks/chunks.go#L389-L395

**Proposed changes:**
- Remove `NewReader` function.
