### PR TITLE
Several small fixes

### DIFF
--- a/compact.go
+++ b/compact.go
@@ -217,7 +217,7 @@ func (c *LeveledCompactor) plan(dms []dirMeta) ([]string, error) {
 	for i := len(dms) - 1; i >= 0; i-- {
 		meta := dms[i].meta
 		if meta.MaxTime-meta.MinTime < c.ranges[len(c.ranges)/2] {
-			continue
+			break
 		}
 		if float64(meta.Stats.NumTombstones)/float64(meta.Stats.NumSeries+1) > 0.05 {
 			return []string{dms[i].dir}, nil

--- a/compact.go
+++ b/compact.go
@@ -217,7 +217,7 @@ func (c *LeveledCompactor) plan(dms []dirMeta) ([]string, error) {
 	for i := len(dms) - 1; i >= 0; i-- {
 		meta := dms[i].meta
 		if meta.MaxTime-meta.MinTime < c.ranges[len(c.ranges)/2] {
-			break
+			continue
 		}
 		if float64(meta.Stats.NumTombstones)/float64(meta.Stats.NumSeries+1) > 0.05 {
 			return []string{dms[i].dir}, nil
@@ -309,7 +309,7 @@ func splitByRange(ds []dirMeta, tr int64) [][]dirMeta {
 		}
 		// Skip blocks that don't fall into the range. This can happen via mis-alignment or
 		// by being the multiple of the intended range.
-		if ds[i].meta.MinTime < t0 || ds[i].meta.MaxTime > t0+tr {
+		if m.MaxTime > t0+tr {
 			i++
 			continue
 		}
@@ -317,7 +317,7 @@ func splitByRange(ds []dirMeta, tr int64) [][]dirMeta {
 		// Add all dirs to the current group that are within [t0, t0+tr].
 		for ; i < len(ds); i++ {
 			// Either the block falls into the next range or doesn't fit at all (checked above).
-			if ds[i].meta.MinTime < t0 || ds[i].meta.MaxTime > t0+tr {
+			if ds[i].meta.MaxTime > t0+tr {
 				break
 			}
 			group = append(group, ds[i])

--- a/db.go
+++ b/db.go
@@ -1037,7 +1037,7 @@ func isBlockDir(fi os.FileInfo) bool {
 	if !fi.IsDir() {
 		return false
 	}
-	_, err := ulid.Parse(fi.Name())
+	_, err := ulid.ParseStrict(fi.Name())
 	return err == nil
 }
 

--- a/db.go
+++ b/db.go
@@ -896,7 +896,7 @@ func (db *DB) Snapshot(dir string, withHead bool) error {
 	if dir == db.dir {
 		return errors.Errorf("cannot snapshot into base directory")
 	}
-	if _, err := ulid.Parse(dir); err == nil {
+	if _, err := ulid.ParseStrict(dir); err == nil {
 		return errors.Errorf("dir must not be a valid ULID")
 	}
 


### PR DESCRIPTION
1. I think you actually want a `continue` instead of `break`.
```
	// Compact any blocks with big enough time range that have >5% tombstones.
	for i := len(dms) - 1; i >= 0; i-- {
		meta := dms[i].meta
		if meta.MaxTime-meta.MinTime < c.ranges[len(c.ranges)/2] {
			break
		}
		if float64(meta.Stats.NumTombstones)/float64(meta.Stats.NumSeries+1) > 0.05 {
			return []string{dms[i].dir}, nil
		}
	}
```

2. `if ds[i].meta.MinTime < t0 || ds[i].meta.MaxTime > t0+tr `, ds[i].meta.MinTime is always larger or equal to t0, no need for first comparison. And I replace `ds[i].meta` with the previously defined variable `m` just for the consistency and simplicity.

3. Also no need for the first comparison for the same reson.
```
// Add all dirs to the current group that are within [t0, t0+tr].
for ; i < len(ds); i++ {
	// Either the block falls into the next range or doesn't fit at all (checked above).
	if ds[i].meta.MinTime < t0 || ds[i].meta.MaxTime > t0+tr
```

4. `ulid.Parse` only checks if the length is 26. I think using `ulid.ParseStrict` to also check the validality of ulid would be better.
```
func isBlockDir(fi os.FileInfo) bool {
	if !fi.IsDir() {
		return false
	}
	_, err := ulid.Parse(fi.Name())
	return err == nil
}
```