### PR TITLE
Make Head.symbols map with size hint

### DIFF
--- a/head.go
+++ b/head.go
@@ -954,7 +954,7 @@ func (h *Head) gc() {
 	h.postings.Delete(deleted)
 
 	// Rebuild symbols and label value indices from what is left in the postings terms.
-	symbols := make(map[string]struct{})
+	symbols := make(map[string]struct{}, len(h.symbols))
 	values := make(map[string]stringset, len(h.values))
 
 	if err := h.postings.Iter(func(t labels.Label, _ index.Postings) error {


### PR DESCRIPTION
Make `Head.symbols` map with size hint
to reduce the number of times the map is resized

---
Benchcmp for [BenchmarkCompaction](https://github.com/prometheus/tsdb/blob/master/compact_test.go#L775)
```
benchmark                                                                                   old ns/op      new ns/op      delta
BenchmarkCompaction/type=normal,blocks=4,series=10000,samplesPerSeriesPerBlock=101-4        5840453439     5412773863     -7.32%
BenchmarkCompaction/type=normal,blocks=4,series=10000,samplesPerSeriesPerBlock=1001-4       8872856728     8539795503     -3.75%
BenchmarkCompaction/type=vertical,blocks=4,series=10000,samplesPerSeriesPerBlock=101-4      5820110035     5582715232     -4.08%
BenchmarkCompaction/type=vertical,blocks=4,series=10000,samplesPerSeriesPerBlock=1001-4     8704204708     7755268645     -10.90%
```

// Skip `case[2:4]` `case[6:8]`, these cases take a long time to run on my Mac (:  
