### PR TITLE
Remove unused statement from index test

### DIFF
--- a/index/index_test.go
+++ b/index/index_test.go
@@ -299,7 +299,6 @@ func TestPersistence_index_e2e(t *testing.T) {
 			valset[l.Value] = struct{}{}
 		}
 		postings.Add(uint64(i), s.labels)
-		i++
 	}
 
 	for k, v := range values {


### PR DESCRIPTION
Remove unused `i++` statement from index test.
