### PR TITLE
Fix typos in comments

### DIFF
--- a/chunks/chunks.go
+++ b/chunks/chunks.go
@@ -65,7 +65,7 @@ func (cm *Meta) writeHash(h hash.Hash) error {
 	return nil
 }
 
-// Returns true if the chunk overlaps [mint, maxt].
+// OverlapsClosedInterval Returns true if the chunk overlaps [mint, maxt].
 func (cm *Meta) OverlapsClosedInterval(mint, maxt int64) bool {
 	// The chunk itself is a closed interval [cm.MinTime, cm.MaxTime].
 	return cm.MinTime <= maxt && mint <= cm.MaxTime

--- a/encoding/encoding.go
+++ b/encoding/encoding.go
@@ -27,7 +27,7 @@ var (
 	ErrInvalidChecksum = errors.New("invalid checksum")
 )
 
-// enbuf is a helper type to populate a byte slice with various types.
+// Encbuf is a helper type to populate a byte slice with various types.
 type Encbuf struct {
 	B []byte
 	C [binary.MaxVarintLen64]byte
@@ -65,14 +65,14 @@ func (e *Encbuf) PutVarint64(x int64) {
 	e.B = append(e.B, e.C[:n]...)
 }
 
-// putVarintStr writes a string to the buffer prefixed by its varint length (in bytes!).
+// PutUvarintStr writes a string to the buffer prefixed by its varint length (in bytes!).
 func (e *Encbuf) PutUvarintStr(s string) {
 	b := *(*[]byte)(unsafe.Pointer(&s))
 	e.PutUvarint(len(b))
 	e.PutString(s)
 }
 
-// putHash appends a hash over the buffers current contents to the buffer.
+// PutHash appends a hash over the buffers current contents to the buffer.
 func (e *Encbuf) PutHash(h hash.Hash) {
 	h.Reset()
 	_, err := h.Write(e.B)
@@ -82,7 +82,7 @@ func (e *Encbuf) PutHash(h hash.Hash) {
 	e.B = h.Sum(e.B)
 }
 
-// decbuf provides safe methods to extract data from a byte slice. It does all
+// Decbuf provides safe methods to extract data from a byte slice. It does all
 // necessary bounds checking and advancing of the byte slice.
 // Several datums can be extracted without checking for errors. However, before using
 // any datum, the err() method must be checked.

--- a/labels/selector.go
+++ b/labels/selector.go
@@ -75,7 +75,7 @@ func NewRegexpMatcher(name, pattern string) (Matcher, error) {
 	return &regexpMatcher{name: name, re: re}, nil
 }
 
-// NewRegexpMatcher returns a new matcher verifying that a value matches
+// NewMustRegexpMatcher returns a new matcher verifying that a value matches
 // the regular expression pattern. Will panic if the pattern is not a valid
 // regular expression.
 func NewMustRegexpMatcher(name, pattern string) Matcher {


### PR DESCRIPTION
Fix some typos in comments.

Make method descriptions and method signatures consistent in godoc.

https://godoc.org/github.com/prometheus/tsdb/encoding#Encbuf.PutUvarintStr

![image](https://user-images.githubusercontent.com/11815801/54895530-ef97bc00-4efa-11e9-80b2-a2078f0de1db.png)

