### PR TITLE
Add filtering on ref of samples and tombstones in checkpoint.go

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -193,7 +193,7 @@ func Checkpoint(w *wal.WAL, from, to int, keep func(id uint64) bool, mint int64)
 			// Drop irrelevant samples in place.
 			repl := samples[:0]
 			for _, s := range samples {
-				if s.T >= mint {
+				if keep(s.Ref) && s.T >= mint {
 					repl = append(repl, s)
 				}
 			}
@@ -212,7 +212,7 @@ func Checkpoint(w *wal.WAL, from, to int, keep func(id uint64) bool, mint int64)
 			repl := tstones[:0]
 			for _, s := range tstones {
 				for _, iv := range s.intervals {
-					if iv.Maxt >= mint {
+					if keep(s.ref) && iv.Maxt >= mint {
 						repl = append(repl, s)
 						break
 					}

--- a/checkpoint_test.go
+++ b/checkpoint_test.go
@@ -149,7 +149,7 @@ func TestCheckpoint(t *testing.T) {
 			{ref: 3, intervals: Intervals{{last, last + 30000}}},
 		}, nil)
 		testutil.Ok(t, w.Log(b))
-		
+
 		last += 100
 	}
 	testutil.Ok(t, w.Close())
@@ -186,14 +186,14 @@ func TestCheckpoint(t *testing.T) {
 			samples, err := dec.Samples(rec, nil)
 			testutil.Ok(t, err)
 			for _, s := range samples {
-				testutil.Assert(t, s.Ref % 2 == 0, "sample with wrong Ref")
+				testutil.Assert(t, s.Ref%2 == 0, "sample with wrong Ref")
 				testutil.Assert(t, s.T >= last/2, "sample with wrong timestamp")
 			}
 		case RecordTombstones:
 			stones, err := dec.Tombstones(rec, nil)
 			testutil.Ok(t, err)
 			for _, s := range stones {
-				testutil.Assert(t, s.ref % 2 == 0, "tombstone with wrong ref")
+				testutil.Assert(t, s.ref%2 == 0, "tombstone with wrong ref")
 				for _, iv := range s.intervals {
 					testutil.Assert(t, iv.Maxt >= last/2, "tombstone with wrong interval")
 				}

--- a/head.go
+++ b/head.go
@@ -906,7 +906,7 @@ func (h *Head) Delete(mint, maxt int64, ms ...labels.Matcher) error {
 
 // chunkRewrite re-writes the chunks which overlaps with deleted ranges
 // and removes the samples in the deleted ranges.
-// Chunks is deleted if no samples are left at the end.
+// Chunks are deleted if no samples are left at the end.
 func (h *Head) chunkRewrite(ref uint64, dranges Intervals) (err error) {
 	if len(dranges) == 0 {
 		return nil
@@ -1038,7 +1038,7 @@ func (h *headChunkReader) Close() error {
 }
 
 // packChunkID packs a seriesID and a chunkID within it into a global 8 byte ID.
-// It panicks if the seriesID exceeds 5 bytes or the chunk ID 3 bytes.
+// It panics if the seriesID exceeds 5 bytes or the chunk ID 3 bytes.
 func packChunkID(seriesID, chunkID uint64) uint64 {
 	if seriesID > (1<<40)-1 {
 		panic("series ID exceeds 5 bytes")


### PR DESCRIPTION
https://github.com/prometheus/tsdb/blob/db9177de0cc7fec169bda0ede005ffd6d6fd1d80/checkpoint.go#L102
As title, I think `keep` function should also be applied on samples and tombstones.