### PR TITLE
make Close methods for the querier safe to call more than once.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## master / unreleased
+ - [BUGFIX] Calling Close more than once on a querier doesn't caue a panic anymore.
+
 
 ## 0.7.0
  - [CHANGE] tsdb now requires golang 1.12 or higher.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## master / unreleased
- - [BUGFIX] Calling Close more than once on a querier doesn't caue a panic anymore.
+ - [BUGFIX] Calling `Close` more than once on a querier returns an error instead of a panic.
 
 
 ## 0.7.0

--- a/querier.go
+++ b/querier.go
@@ -254,15 +254,16 @@ func (q *blockQuerier) LabelValuesFor(string, labels.Label) ([]string, error) {
 }
 
 func (q *blockQuerier) Close() error {
-	var merr tsdb_errors.MultiError
-	if !q.closed {
-		merr.Add(q.index.Close())
-		merr.Add(q.chunks.Close())
-		merr.Add(q.tombstones.Close())
-		q.closed = true
-		return merr.Err()
+	if q.closed {
+		return errors.New("block querier already closed")
 	}
-	return errors.New("block querier already closed")
+
+	var merr tsdb_errors.MultiError
+	merr.Add(q.index.Close())
+	merr.Add(q.chunks.Close())
+	merr.Add(q.tombstones.Close())
+	q.closed = true
+	return merr.Err()
 }
 
 // PostingsForMatchers assembles a single postings iterator against the index reader

--- a/querier_test.go
+++ b/querier_test.go
@@ -1924,5 +1924,5 @@ func TestClose(t *testing.T) {
 	q, err := db.Querier(0, 20)
 	testutil.Ok(t, err)
 	testutil.Ok(t, q.Close())
-	testutil.Ok(t, q.Close())
+	testutil.NotOk(t, q.Close())
 }

--- a/querier_test.go
+++ b/querier_test.go
@@ -1899,3 +1899,27 @@ func TestPostingsForMatchers(t *testing.T) {
 	}
 
 }
+
+// TestClose ensures that calling Close more than once doesn't block and doesn't panic.
+func TestClose(t *testing.T) {
+	dir, err := ioutil.TempDir("", "test_storage")
+	if err != nil {
+		t.Fatalf("Opening test dir failed: %s", err)
+	}
+	defer func() {
+		testutil.Ok(t, os.RemoveAll(dir))
+	}()
+
+	createBlock(t, dir, genSeries(1, 1, 0, 10))
+	createBlock(t, dir, genSeries(1, 1, 10, 20))
+
+	db, err := Open(dir, nil, nil, DefaultOptions)
+	if err != nil {
+		t.Fatalf("Opening test storage failed: %s", err)
+	}
+
+	q, err := db.Querier(0, 20)
+	testutil.Ok(t, err)
+	testutil.Ok(t, q.Close())
+	testutil.Ok(t, q.Close())
+}

--- a/querier_test.go
+++ b/querier_test.go
@@ -1917,6 +1917,9 @@ func TestClose(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Opening test storage failed: %s", err)
 	}
+	defer func() {
+		testutil.Ok(t, db.Close())
+	}()
 
 	q, err := db.Querier(0, 20)
 	testutil.Ok(t, err)

--- a/wal/wal.go
+++ b/wal/wal.go
@@ -159,12 +159,12 @@ type WAL struct {
 	logger      log.Logger
 	segmentSize int
 	mtx         sync.RWMutex
-	segment     *Segment // active segment
-	donePages   int      // pages written to the segment
-	page        *page    // active page
+	segment     *Segment // Active segment.
+	donePages   int      // Pages written to the segment.
+	page        *page    // Active page.
 	stopc       chan chan struct{}
 	actorc      chan func()
-	closed      bool // To allow calling Close() more than once without blocking.
+	close       sync.Once
 
 	fsyncDuration   prometheus.Summary
 	pageFlushes     prometheus.Counter
@@ -605,31 +605,30 @@ func (w *WAL) Close() (err error) {
 	w.mtx.Lock()
 	defer w.mtx.Unlock()
 
-	if w.closed {
-		return nil
-	}
-
-	// Flush the last page and zero out all its remaining size.
-	// We must not flush an empty page as it would falsely signal
-	// the segment is done if we start writing to it again after opening.
-	if w.page.alloc > 0 {
-		if err := w.flushPage(true); err != nil {
-			return err
+	// Ensure any sequential call is noop and
+	// calling Close more than once doesn't block.
+	w.close.Do(func() {
+		// Flush the last page and zero out all its remaining size.
+		// We must not flush an empty page as it would falsely signal
+		// the segment is done if we start writing to it again after opening.
+		if w.page.alloc > 0 {
+			if err = w.flushPage(true); err != nil {
+				return
+			}
 		}
-	}
 
-	donec := make(chan struct{})
-	w.stopc <- donec
-	<-donec
+		donec := make(chan struct{})
+		w.stopc <- donec
+		<-donec
 
-	if err = w.fsync(w.segment); err != nil {
-		level.Error(w.logger).Log("msg", "sync previous segment", "err", err)
-	}
-	if err := w.segment.Close(); err != nil {
-		level.Error(w.logger).Log("msg", "close previous segment", "err", err)
-	}
-	w.closed = true
-	return nil
+		if err := w.fsync(w.segment); err != nil {
+			level.Error(w.logger).Log("msg", "sync previous segment", "err", err)
+		}
+		if err := w.segment.Close(); err != nil {
+			level.Error(w.logger).Log("msg", "close previous segment", "err", err)
+		}
+	})
+	return err
 }
 
 type segmentRef struct {

--- a/wal/wal_test.go
+++ b/wal/wal_test.go
@@ -315,7 +315,7 @@ func TestClose(t *testing.T) {
 	w, err := NewSize(nil, nil, dir, pageSize)
 	testutil.Ok(t, err)
 	testutil.Ok(t, w.Close())
-	testutil.Ok(t, w.Close())
+	testutil.NotOk(t, w.Close())
 }
 
 func BenchmarkWAL_LogBatched(b *testing.B) {

--- a/wal/wal_test.go
+++ b/wal/wal_test.go
@@ -305,6 +305,19 @@ func TestCorruptAndCarryOn(t *testing.T) {
 	}
 }
 
+// TestClose ensures that calling Close more than once doesn't panic and doesn't block.
+func TestClose(t *testing.T) {
+	dir, err := ioutil.TempDir("", "wal_repair")
+	testutil.Ok(t, err)
+	defer func() {
+		testutil.Ok(t, os.RemoveAll(dir))
+	}()
+	w, err := NewSize(nil, nil, dir, pageSize)
+	testutil.Ok(t, err)
+	testutil.Ok(t, w.Close())
+	testutil.Ok(t, w.Close())
+}
+
 func BenchmarkWAL_LogBatched(b *testing.B) {
 	dir, err := ioutil.TempDir("", "bench_logbatch")
 	testutil.Ok(b, err)


### PR DESCRIPTION
from: https://github.com/prometheus/prometheus/issues/5408

`querier.Close` is called more than once somewhere in the rules Manager. I will still troubleshoot why this happens.

Regardless of this the method should be safe to be called more than once and this PR fixes this and also adds tests for the WAL and querier Close methods.

Signed-off-by: Krasi Georgiev <kgeorgie@redhat.com>