### PR TITLE
fix wal panic when page flush fails.

### DIFF
--- a/wal/wal.go
+++ b/wal/wal.go
@@ -429,7 +429,6 @@ func (w *WAL) flushPage(clear bool) error {
 	// No more data will fit into the page. Enqueue and clear it.
 	if clear {
 		p.alloc = pageSize // Write till end of page.
-		w.pageCompletions.Inc()
 	}
 	n, err := w.segment.Write(p.buf[p.flushed:p.alloc])
 	if err != nil {
@@ -445,6 +444,7 @@ func (w *WAL) flushPage(clear bool) error {
 		p.alloc = 0
 		p.flushed = 0
 		w.donePages++
+		w.pageCompletions.Inc()
 	}
 	return nil
 }
@@ -499,6 +499,13 @@ func (w *WAL) Log(recs ...[]byte) error {
 // the final record of a batch, the record is bigger than the page size or
 // the current page is full.
 func (w *WAL) log(rec []byte, final bool) error {
+	// When the last page flush failed the page will remain full.
+	// When the page is full, need to flush it before trying to add more records to it.
+	if w.page.full() {
+		if err := w.flushPage(true); err != nil {
+			return err
+		}
+	}
 	// If the record is too big to fit within the active page in the current
 	// segment, terminate the active segment and advance to the next one.
 	// This ensures that records do not cross segment boundaries.

--- a/wal/wal.go
+++ b/wal/wal.go
@@ -426,7 +426,8 @@ func (w *WAL) flushPage(clear bool) error {
 	p := w.page
 	clear = clear || p.full()
 
-	// No more data will fit into the page. Enqueue and clear it.
+	// No more data will fit into the page or an implicit clear.
+	// Enqueue and clear it.
 	if clear {
 		p.alloc = pageSize // Write till end of page.
 	}
@@ -495,9 +496,10 @@ func (w *WAL) Log(recs ...[]byte) error {
 	return nil
 }
 
-// log writes rec to the log and forces a flush of the current page if its
-// the final record of a batch, the record is bigger than the page size or
-// the current page is full.
+// log writes rec to the log and forces a flush of the current page if:
+// - the final record of a batch
+// - the record is bigger than the page size
+// - the current page is full.
 func (w *WAL) log(rec []byte, final bool) error {
 	// When the last page flush failed the page will remain full.
 	// When the page is full, need to flush it before trying to add more records to it.


### PR DESCRIPTION
fixes: https://github.com/prometheus/prometheus/issues/3283

New records should be added to the page only when the last flush
succeeded. Otherwise the page would be full and panics when trying to
add a new record.


to replicate the bug:
```
dd if=/dev/zero of=tmp/data.img bs=1M count=20 // create a 20mb disk image
mkfs.ext4 /tmp/data.img
mkdir /tmp/prometheus/
sudo mount -t ext4 -o loop /tmp/data.img /tmp/prometheus/
GO111MODULE=on go run cmd/prometheus/main.go   --config.file=.local/simpleMany.yaml --storage.tsdb.path=/tmp/prometheus   --storage.tsdb.wal-segment-size=1MB
```


before the fix this will panic when the disk image is full because it is trying to add more records to the page when it is already full.

At the moment can't think of simple test to test for this, but will add it to https://github.com/prometheus/tsdb/issues/579 if we figure out how to inject file system faults.



Signed-off-by: Krasi Georgiev <kgeorgie@redhat.com>