### PR TITLE
Avoid potential collision of createIdxChkReaders in querier_test.go

### DIFF
--- a/querier_test.go
+++ b/querier_test.go
@@ -207,7 +207,6 @@ func createIdxChkReaders(tc []seriesSamples) (IndexReader, ChunkReader, int64, i
 	blockMaxt := int64(math.MinInt64)
 
 	var chunkRef uint64
-	chunkRef = 0
 	for i, s := range tc {
 		i = i + 1 // 0 is not a valid posting.
 		metas := make([]chunks.Meta, 0, len(s.chunks))

--- a/querier_test.go
+++ b/querier_test.go
@@ -206,13 +206,12 @@ func createIdxChkReaders(tc []seriesSamples) (IndexReader, ChunkReader, int64, i
 	blockMint := int64(math.MaxInt64)
 	blockMaxt := int64(math.MinInt64)
 
+	var chunkRef uint64
+	chunkRef = 0
 	for i, s := range tc {
 		i = i + 1 // 0 is not a valid posting.
 		metas := make([]chunks.Meta, 0, len(s.chunks))
 		for _, chk := range s.chunks {
-			// Collisions can be there, but for tests, its fine.
-			ref := rand.Uint64()
-
 			if chk[0].t < blockMint {
 				blockMint = chk[0].t
 			}
@@ -223,7 +222,7 @@ func createIdxChkReaders(tc []seriesSamples) (IndexReader, ChunkReader, int64, i
 			metas = append(metas, chunks.Meta{
 				MinTime: chk[0].t,
 				MaxTime: chk[len(chk)-1].t,
-				Ref:     ref,
+				Ref:     chunkRef,
 			})
 
 			chunk := chunkenc.NewXORChunk()
@@ -231,7 +230,8 @@ func createIdxChkReaders(tc []seriesSamples) (IndexReader, ChunkReader, int64, i
 			for _, smpl := range chk {
 				app.Append(smpl.t, smpl.v)
 			}
-			chkReader[ref] = chunk
+			chkReader[chunkRef] = chunk
+			chunkRef += 1
 		}
 
 		ls := labels.FromMap(s.lset)


### PR DESCRIPTION
as title, make ref a monotonically increasing number to avoid the potential collision
https://github.com/prometheus/tsdb/blob/4b3a5ac5d36e5262d2656c8d149e137c2d1fab12/querier_test.go#L213-L214
