### PR TITLE
Avoid allocation in mergedPostings.Seek.

### DIFF
--- a/index/postings.go
+++ b/index/postings.go
@@ -483,11 +483,12 @@ func (it *mergedPostings) Seek(id uint64) bool {
 	// Heapifying when there is lots of Seeks is inefficient,
 	// mark to be re-heapified on the Next() call.
 	it.heaped = false
-	newH := make(postingsHeap, 0, len(it.h))
 	lowest := ^uint64(0)
+	n := 0
 	for _, i := range it.h {
 		if i.Seek(id) {
-			newH = append(newH, i)
+			it.h[n] = i
+			n++
 			if i.At() < lowest {
 				lowest = i.At()
 			}
@@ -498,7 +499,7 @@ func (it *mergedPostings) Seek(id uint64) bool {
 			}
 		}
 	}
-	it.h = newH
+	it.h = it.h[:n]
 	if len(it.h) == 0 {
 		return false
 	}


### PR DESCRIPTION
See
https://github.com/prometheus/prometheus/issues/5424#issuecomment-485199651

```
benchmark                                                            old
ns/op      new ns/op       delta
BenchmarkHeadPostingForMatchers/n="1"-4
5266           5267            +0.02%
BenchmarkHeadPostingForMatchers/n="1",j="foo"-4
6469           7801            +20.59%
BenchmarkHeadPostingForMatchers/j="foo",n="1"-4
4984           4963            -0.42%
BenchmarkHeadPostingForMatchers/n="1",j!="foo"-4
7137           7527            +5.46%
BenchmarkHeadPostingForMatchers/i=~".*"-4
8055830839     8117651746      +0.77%
BenchmarkHeadPostingForMatchers/i=~".+"-4
9369298293     9742710251      +3.99%
BenchmarkHeadPostingForMatchers/i=~""-4
2363120708     2507789029      +6.12%
BenchmarkHeadPostingForMatchers/i!=""-4
9387069195     11740628557     +25.07%
BenchmarkHeadPostingForMatchers/n="1",i=~".*",j="foo"-4
109668312      107644136       -1.85%
BenchmarkHeadPostingForMatchers/n="1",i=~".*",i!="2",j="foo"-4
106022679      105759760       -0.25%
BenchmarkHeadPostingForMatchers/n="1",i!="",j="foo"-4
330201810      266421024       -19.32%
BenchmarkHeadPostingForMatchers/n="1",i=~".+",j="foo"-4
355627801      292774913       -17.67%
BenchmarkHeadPostingForMatchers/n="1",i=~"1.+",j="foo"-4
108132305      106697690       -1.33%
BenchmarkHeadPostingForMatchers/n="1",i=~".+",i!="2",j="foo"-4
358836972      362579998       +1.04%
BenchmarkHeadPostingForMatchers/n="1",i=~".+",i!~"2.*",j="foo"-4
555879392      575858378       +3.59%

benchmark                                                            old
allocs     new allocs     delta
BenchmarkHeadPostingForMatchers/n="1"-4                              8
8              +0.00%
BenchmarkHeadPostingForMatchers/n="1",j="foo"-4                      11
11             +0.00%
BenchmarkHeadPostingForMatchers/j="foo",n="1"-4                      11
11             +0.00%
BenchmarkHeadPostingForMatchers/n="1",j!="foo"-4                     17
17             +0.00%
BenchmarkHeadPostingForMatchers/i=~".*"-4                            58
58             +0.00%
BenchmarkHeadPostingForMatchers/i=~".+"-4
100115         100115         +0.00%
BenchmarkHeadPostingForMatchers/i=~""-4
100125         100125         +0.00%
BenchmarkHeadPostingForMatchers/i!=""-4
100112         100112         +0.00%
BenchmarkHeadPostingForMatchers/n="1",i=~".*",j="foo"-4              19
19             +0.00%
BenchmarkHeadPostingForMatchers/n="1",i=~".*",i!="2",j="foo"-4       22
22             +0.00%
BenchmarkHeadPostingForMatchers/n="1",i!="",j="foo"-4
100109         100079         -0.03%
BenchmarkHeadPostingForMatchers/n="1",i=~".+",j="foo"-4
100110         100079         -0.03%
BenchmarkHeadPostingForMatchers/n="1",i=~"1.+",j="foo"-4
11176          11167          -0.08%
BenchmarkHeadPostingForMatchers/n="1",i=~".+",i!="2",j="foo"-4
100112         100082         -0.03%
BenchmarkHeadPostingForMatchers/n="1",i=~".+",i!~"2.*",j="foo"-4
111307         111277         -0.03%

benchmark                                                            old
bytes     new bytes     delta
BenchmarkHeadPostingForMatchers/n="1"-4
1360          1360          +0.00%
BenchmarkHeadPostingForMatchers/n="1",j="foo"-4
1392          1392          +0.00%
BenchmarkHeadPostingForMatchers/j="foo",n="1"-4
1392          1392          +0.00%
BenchmarkHeadPostingForMatchers/n="1",j!="foo"-4
1520          1520          +0.00%
BenchmarkHeadPostingForMatchers/i=~".*"-4
258254040     258254040     +0.00%
BenchmarkHeadPostingForMatchers/i=~".+"-4
281554280     281554280     +0.00%
BenchmarkHeadPostingForMatchers/i=~""-4
241554888     241554888     +0.00%
BenchmarkHeadPostingForMatchers/i!=""-4
281553664     281553664     +0.00%
BenchmarkHeadPostingForMatchers/n="1",i=~".*",j="foo"-4
1607277       1607277       +0.00%
BenchmarkHeadPostingForMatchers/n="1",i=~".*",i!="2",j="foo"-4
1607389       1607389       +0.00%
BenchmarkHeadPostingForMatchers/n="1",i!="",j="foo"-4
73076560      24907600      -65.92%
BenchmarkHeadPostingForMatchers/n="1",i=~".+",j="foo"-4
73076765      24907723      -65.92%
BenchmarkHeadPostingForMatchers/n="1",i=~"1.+",j="foo"-4
5416925       3794909       -29.94%
BenchmarkHeadPostingForMatchers/n="1",i=~".+",i!="2",j="foo"-4
73076779      24907819      -65.92%
BenchmarkHeadPostingForMatchers/n="1",i=~".+",i!~"2.*",j="foo"-4
99874860      51705900      -48.23%
```

Signed-off-by: Brian Brazil <brian.brazil@robustperception.io>