### PR TITLE
Export the current segment index as a metic.

### DIFF
--- a/wal/wal_test.go
+++ b/wal/wal_test.go
@@ -345,6 +345,7 @@ func TestSegmentMetric(t *testing.T) {
 		testutil.Ok(t, err)
 	}
 	testutil.Assert(t, client_testutil.ToFloat64(w.currentSegment) == initialSegment+1, "segment metric did not increment after segment rotation")
+	testutil.Ok(t, w.Close())
 }
 
 func BenchmarkWAL_LogBatched(b *testing.B) {

--- a/wal/wal_test.go
+++ b/wal/wal_test.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	client_testutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/tsdb/testutil"
 )
 
@@ -316,6 +317,34 @@ func TestClose(t *testing.T) {
 	testutil.Ok(t, err)
 	testutil.Ok(t, w.Close())
 	testutil.NotOk(t, w.Close())
+}
+
+func TestSegmentMetric(t *testing.T) {
+	var (
+		segmentSize = pageSize
+		recordSize  = (pageSize / 2) - recordHeaderSize
+	)
+
+	dir, err := ioutil.TempDir("", "segment_metric")
+	testutil.Ok(t, err)
+	defer func() {
+		testutil.Ok(t, os.RemoveAll(dir))
+	}()
+	w, err := NewSize(nil, nil, dir, segmentSize)
+	testutil.Ok(t, err)
+
+	initialSegment := client_testutil.ToFloat64(w.currentSegment)
+
+	// Write 3 records, each of which is half the segment size, meaning we should rotate to the next segment.
+	for i := 0; i < 3; i++ {
+		buf := make([]byte, recordSize)
+		_, err := rand.Read(buf)
+		testutil.Ok(t, err)
+
+		err = w.Log(buf)
+		testutil.Ok(t, err)
+	}
+	testutil.Assert(t, client_testutil.ToFloat64(w.currentSegment) == initialSegment+1, "segment metric did not increment after segment rotation")
 }
 
 func BenchmarkWAL_LogBatched(b *testing.B) {


### PR DESCRIPTION
Add a metric for the current segment index that TSDB will use for the WAL. Useful for looking into WAL watcher/tailer issues.

Signed-off-by: Callum Styan <callumstyan@gmail.com>