### PR TITLE
Don't crash on an unknown tombstone ref.

### DIFF
--- a/head.go
+++ b/head.go
@@ -421,6 +421,10 @@ func (h *Head) loadWAL(r *wal.Reader) error {
 					if itv.Maxt < h.minValidTime {
 						continue
 					}
+					if m := h.series.getByID(s.ref); m == nil {
+						unknownRefs++
+						continue
+					}
 					allStones.addInterval(s.ref, itv)
 				}
 			}

--- a/head_test.go
+++ b/head_test.go
@@ -114,6 +114,9 @@ func TestHead_ReadWAL(t *testing.T) {
 			{Ref: 10, T: 101, V: 5},
 			{Ref: 50, T: 101, V: 6},
 		},
+		[]Stone{
+			{ref: 0, intervals: []Interval{{Mint: 99, Maxt: 101}}},
+		},
 	}
 	dir, err := ioutil.TempDir("", "test_read_wal")
 	testutil.Ok(t, err)


### PR DESCRIPTION
Fixes https://github.com/prometheus/prometheus/issues/5562

This shouldn't happen in the first place, but at least let's be resilient and not crash. It's not as if we can delete anything from an unknown series anyway.