### PR TITLE
Always create a new clean segment when starting the WAL.

### DIFF
--- a/head.go
+++ b/head.go
@@ -499,7 +499,7 @@ func (h *Head) Init(minValidTime int64) error {
 		return errors.Wrap(err, "finding WAL segments")
 	}
 
-	// Backfill segments from the last checkpoint onwards.
+	// Backfill segments from the most recent checkpoint onwards.
 	for i := startFrom; i <= last; i++ {
 		s, err := wal.OpenReadSegment(wal.SegmentName(h.wal.Dir(), i))
 		if err != nil {

--- a/head.go
+++ b/head.go
@@ -14,6 +14,7 @@
 package tsdb
 
 import (
+	"fmt"
 	"math"
 	"runtime"
 	"sort"
@@ -492,22 +493,32 @@ func (h *Head) Init(minValidTime int64) error {
 		startFrom++
 	}
 
-	// Backfill segments from the last checkpoint onwards
-	sr, err := wal.NewSegmentsRangeReader(wal.SegmentRange{Dir: h.wal.Dir(), First: startFrom, Last: -1})
+	// Find the last segment.
+	_, last, err := h.wal.Segments()
 	if err != nil {
-		return errors.Wrap(err, "open WAL segments")
+		return errors.Wrap(err, "finding WAL segments")
 	}
 
-	err = h.loadWAL(wal.NewReader(sr))
-	sr.Close() // Close the reader so that if there was an error the repair can remove the corrupted file under Windows.
-	if err == nil {
-		return nil
+	// Backfill segments from the last checkpoint onwards.
+	for i := startFrom; i <= last; i++ {
+		s, err := wal.OpenReadSegment(wal.SegmentName(h.wal.Dir(), i))
+		if err != nil {
+			return errors.Wrap(err, fmt.Sprintf("open WAL segment: %d", i))
+		}
+
+		sr := wal.NewSegmentBufReader(s)
+		err = h.loadWAL(wal.NewReader(sr))
+		sr.Close() // Close the reader so that if there was an error the repair can remove the corrupted file under Windows.
+		if err == nil {
+			continue
+		}
+		level.Warn(h.logger).Log("msg", "encountered WAL error, attempting repair", "err", err)
+		h.metrics.walCorruptionsTotal.Inc()
+		if err := h.wal.Repair(err); err != nil {
+			return errors.Wrap(err, "repair corrupted WAL")
+		}
 	}
-	level.Warn(h.logger).Log("msg", "encountered WAL error, attempting repair", "err", err)
-	h.metrics.walCorruptionsTotal.Inc()
-	if err := h.wal.Repair(err); err != nil {
-		return errors.Wrap(err, "repair corrupted WAL")
-	}
+
 	return nil
 }
 

--- a/wal/wal.go
+++ b/wal/wal.go
@@ -372,6 +372,9 @@ func (w *WAL) Repair(origErr error) error {
 		return errors.Wrap(err, "delete corrupted segment")
 	}
 
+	// Explicitly close the the segment we just repaired to avoid issues with Windows.
+	s.Close()
+
 	// We always want to start writing to a new Segment rather than an existing
 	// Segment, which is handled by NewSize, but earlier in Repair we're deleting
 	// all segments that come after the corrupted Segment. Recreate a new Segment here.
@@ -382,7 +385,6 @@ func (w *WAL) Repair(origErr error) error {
 	if err := w.setSegment(s); err != nil {
 		return err
 	}
-
 	return nil
 }
 

--- a/wal/wal.go
+++ b/wal/wal.go
@@ -359,6 +359,9 @@ func (w *WAL) Repair(origErr error) error {
 	}
 	// We expect an error here from r.Err(), so nothing to handle.
 
+	// We need to pad to the end of the last page in the repaired segment
+	w.flushPage(true)
+
 	// We explicitly close even when there is a defer for Windows to be
 	// able to delete it. The defer is in place to close it in-case there
 	// are errors above.

--- a/wal/wal_test.go
+++ b/wal/wal_test.go
@@ -290,6 +290,10 @@ func TestCorruptAndCarryOn(t *testing.T) {
 		err = w.Repair(corruptionErr)
 		testutil.Ok(t, err)
 
+		// Ensure that we have a completely clean slate after reapiring.
+		testutil.Equals(t, w.segment.Index(), 1) // We corrupted segment 0.
+		testutil.Equals(t, w.donePages, 0)
+
 		for i := 0; i < 5; i++ {
 			buf := make([]byte, recordSize)
 			_, err := rand.Read(buf)

--- a/wal/wal_test.go
+++ b/wal/wal_test.go
@@ -146,13 +146,11 @@ func TestWAL_Repair(t *testing.T) {
 			first, last, err := w.Segments()
 			testutil.Ok(t, err)
 
-			// Backfill segments from the last checkpoint onwards
+			// Backfill segments from the most recent checkpoint onwards.
 			for i := first; i <= last; i++ {
 				s, err := OpenReadSegment(SegmentName(w.Dir(), i))
 				testutil.Ok(t, err)
-				// if err != nil {
-				// 	return errors.Wrap(err, fmt.Sprintf("open WAL segment: %d", i))
-				// }
+
 				sr := NewSegmentBufReader(s)
 				testutil.Ok(t, err)
 				r := NewReader(sr)

--- a/wal/wal_test.go
+++ b/wal/wal_test.go
@@ -156,6 +156,10 @@ func TestWAL_Repair(t *testing.T) {
 				r := NewReader(sr)
 				for r.Next() {
 				}
+
+				//Close the segment so we don't break things on Windows.
+				s.Close()
+
 				// No corruption in this segment.
 				if r.Err() == nil {
 					continue


### PR DESCRIPTION
Also changes repair to read a single segment at a time as the offset detection is still problematic.

Signed-off-by: Callum Styan <callumstyan@gmail.com>

@brian-brazil 
cc @gouthamve 