### PR TITLE
Optionally compress the WAL using Snappy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## master / unreleased
-
+ - [FEATURE] Provide option to compress WAL records using Snappy. [#609](https://github.com/prometheus/tsdb/pull/609)
 
 ## 0.8.0
  - [BUGFIX] Calling `Close` more than once on a querier returns an error instead of a panic.

--- a/checkpoint.go
+++ b/checkpoint.go
@@ -135,7 +135,7 @@ func Checkpoint(w *wal.WAL, from, to int, keep func(id uint64) bool, mint int64)
 	if err := os.MkdirAll(cpdirtmp, 0777); err != nil {
 		return nil, errors.Wrap(err, "create checkpoint dir")
 	}
-	cp, err := wal.New(nil, nil, cpdirtmp)
+	cp, err := wal.New(nil, nil, cpdirtmp, w.CompressionEnabled())
 	if err != nil {
 		return nil, errors.Wrap(err, "open checkpoint")
 	}

--- a/db.go
+++ b/db.go
@@ -51,6 +51,7 @@ var DefaultOptions = &Options{
 	BlockRanges:            ExponentialBlockRanges(int64(2*time.Hour)/1e6, 3, 5),
 	NoLockfile:             false,
 	AllowOverlappingBlocks: false,
+	WALCompression:         false,
 }
 
 // Options of the DB storage.
@@ -80,6 +81,9 @@ type Options struct {
 	// Overlapping blocks are allowed if AllowOverlappingBlocks is true.
 	// This in-turn enables vertical compaction and vertical query merge.
 	AllowOverlappingBlocks bool
+
+	// WALCompression will turn on Snappy compression for records on the WAL.
+	WALCompression bool
 }
 
 // Appender allows appending a batch of data. It must be completed with a
@@ -306,7 +310,7 @@ func Open(dir string, l log.Logger, r prometheus.Registerer, opts *Options) (db 
 		if opts.WALSegmentSize > 0 {
 			segmentSize = opts.WALSegmentSize
 		}
-		wlog, err = wal.NewSize(l, r, filepath.Join(dir, "wal"), segmentSize)
+		wlog, err = wal.NewSize(l, r, filepath.Join(dir, "wal"), segmentSize, opts.WALCompression)
 		if err != nil {
 			return nil, err
 		}

--- a/db_test.go
+++ b/db_test.go
@@ -1404,7 +1404,7 @@ func TestInitializeHeadTimestamp(t *testing.T) {
 		}()
 
 		testutil.Ok(t, os.MkdirAll(path.Join(dir, "wal"), 0777))
-		w, err := wal.New(nil, nil, path.Join(dir, "wal"))
+		w, err := wal.New(nil, nil, path.Join(dir, "wal"), false)
 		testutil.Ok(t, err)
 
 		var enc RecordEncoder
@@ -1454,7 +1454,7 @@ func TestInitializeHeadTimestamp(t *testing.T) {
 		createBlock(t, dir, genSeries(1, 1, 1000, 6000))
 
 		testutil.Ok(t, os.MkdirAll(path.Join(dir, "wal"), 0777))
-		w, err := wal.New(nil, nil, path.Join(dir, "wal"))
+		w, err := wal.New(nil, nil, path.Join(dir, "wal"), false)
 		testutil.Ok(t, err)
 
 		var enc RecordEncoder

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ require (
 	github.com/cespare/xxhash v1.1.0
 	github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954
 	github.com/go-kit/kit v0.8.0
+	github.com/golang/snappy v0.0.1
 	github.com/oklog/ulid v1.3.1
 	github.com/pkg/errors v0.8.0
 	github.com/prometheus/client_golang v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=
+github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515 h1:T+h1c/A9Gawja4Y9mFVWj2vyii2bbUNDw3kt9VxK2EY=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=

--- a/testutil/directory.go
+++ b/testutil/directory.go
@@ -16,6 +16,7 @@ package testutil
 import (
 	"io/ioutil"
 	"os"
+	"path/filepath"
 )
 
 const (
@@ -126,4 +127,19 @@ func NewTemporaryDirectory(name string, t T) (handler TemporaryDirectory) {
 	}
 
 	return
+}
+
+// DirSize returns the size in bytes of all files in a directory.
+func DirSize(path string) (int64, error) {
+	var size int64
+	err := filepath.Walk(path, func(_ string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			size += info.Size()
+		}
+		return nil
+	})
+	return size, err
 }

--- a/wal.go
+++ b/wal.go
@@ -1246,7 +1246,7 @@ func MigrateWAL(logger log.Logger, dir string) (err error) {
 	if err := os.RemoveAll(tmpdir); err != nil {
 		return errors.Wrap(err, "cleanup replacement dir")
 	}
-	repl, err := wal.New(logger, nil, tmpdir)
+	repl, err := wal.New(logger, nil, tmpdir, false)
 	if err != nil {
 		return errors.Wrap(err, "open new WAL")
 	}

--- a/wal_test.go
+++ b/wal_test.go
@@ -459,7 +459,7 @@ func TestMigrateWAL_Empty(t *testing.T) {
 	wdir := path.Join(dir, "wal")
 
 	// Initialize empty WAL.
-	w, err := wal.New(nil, nil, wdir)
+	w, err := wal.New(nil, nil, wdir, false)
 	testutil.Ok(t, err)
 	testutil.Ok(t, w.Close())
 
@@ -506,7 +506,7 @@ func TestMigrateWAL_Fuzz(t *testing.T) {
 	// Perform migration.
 	testutil.Ok(t, MigrateWAL(nil, wdir))
 
-	w, err := wal.New(nil, nil, wdir)
+	w, err := wal.New(nil, nil, wdir, false)
 	testutil.Ok(t, err)
 
 	// We can properly write some new data after migration.


### PR DESCRIPTION
Compress the WAL records using snappy. Running in test clusters shows that the WAL is half the size with minimal increase in CPU.

Benchmarks:
2012 macbook pro, SATA flash drive
```
go test ./wal -bench . -benchmem -benchtime=5s
goos: darwin
goarch: amd64
pkg: github.com/prometheus/tsdb/wal
BenchmarkWAL_LogBatched/compress=true-8                   500000             13234 ns/op         154.74 MB/s           0 B/op          0 allocs/op
BenchmarkWAL_LogBatched/compress=false-8                 1000000              5278 ns/op         387.96 MB/s           0 B/op          0 allocs/op
BenchmarkWAL_Log/compress=true-8                          500000             13209 ns/op         155.04 MB/s           0 B/op          0 allocs/op
BenchmarkWAL_Log/compress=false-8                         500000             19728 ns/op         103.81 MB/s           0 B/op          0 allocs/op
```

5th Gen Lenovo X1 Carbon, NVMe flash drive
```
go test ./wal -bench . -benchmem -benchtime=5s
goos: linux
goarch: amd64
pkg: github.com/prometheus/tsdb/wal
BenchmarkWAL_LogBatched/compress=true-4                  5000000              1590 ns/op        1287.93 MB/s           0 B/op          0 allocs/op
BenchmarkWAL_LogBatched/compress=false-4                 3000000              6327 ns/op         323.66 MB/s           0 B/op          0 allocs/op
BenchmarkWAL_Log/compress=true-4                         5000000              1555 ns/op        1316.45 MB/s           0 B/op          0 allocs/op
BenchmarkWAL_Log/compress=false-4                        1000000              5862 ns/op         349.36 MB/s           0 B/op          0 allocs/op
```

Closes #599 