### PR TITLE
Fix `make bench`

### DIFF
--- a/cmd/tsdb/main.go
+++ b/cmd/tsdb/main.go
@@ -15,7 +15,6 @@ package main
 
 import (
 	"bufio"
-	"flag"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -106,9 +105,6 @@ func main() {
 			exitWithError(err)
 		}
 		dumpSamples(db, *dumpMinTime, *dumpMaxTime)
-	}
-	if err := flag.CommandLine.Set("log.level", "debug"); err != nil {
-		exitWithError(err)
 	}
 }
 


### PR DESCRIPTION
When running `make bench`, it fails saying
```
>> completed stage=stopStorage duration=502.693441ms
no such flag -log.level
Makefile:27: recipe for target 'bench' failed
make: *** [bench] Error 1
```

Signed-off-by: mrasu <m.rasu.hitsuji@gmail.com>