### PR TITLE
Improvement on postings intersection

### DIFF
--- a/index/postings.go
+++ b/index/postings.go
@@ -341,7 +341,7 @@ func (it *intersectPostings) doNext(id uint64) bool {
 func (it *intersectPostings) Next() bool {
 	for _, p := range it.arr {
 		if !p.Next() {
-			return false 
+			return false
 		}
 		if p.At() > it.cur {
 			it.cur = p.At()
@@ -353,7 +353,7 @@ func (it *intersectPostings) Next() bool {
 func (it *intersectPostings) Seek(id uint64) bool {
 	for _, p := range it.arr {
 		if !p.Seek(id) {
-			return false 
+			return false
 		}
 		if p.At() > it.cur {
 			it.cur = p.At()

--- a/index/postings.go
+++ b/index/postings.go
@@ -340,9 +340,9 @@ func (it *intersectPostings) doNext(id uint64) bool {
 
 func (it *intersectPostings) Next() bool {
 	for _, p := range it.arr {
-                if !p.Next() {
-                        return false 
-                }
+		if !p.Next() {
+			return false 
+		}
 		if p.At() > it.cur {
 			it.cur = p.At()
 		}
@@ -352,9 +352,9 @@ func (it *intersectPostings) Next() bool {
 
 func (it *intersectPostings) Seek(id uint64) bool {
 	for _, p := range it.arr {
-                if !p.Seek(id) {
-                        return false 
-                }
+		if !p.Seek(id) {
+			return false 
+		}
 		if p.At() > it.cur {
 			it.cur = p.At()
 		}

--- a/index/postings_test.go
+++ b/index/postings_test.go
@@ -244,13 +244,45 @@ func BenchmarkIntersect(t *testing.B) {
 	i3 := newListPostings(c...)
 	i4 := newListPostings(d...)
 
-	t.ResetTimer()
-
-	for i := 0; i < t.N; i++ {
-		if _, err := ExpandPostings(Intersect(i1, i2, i3, i4)); err != nil {
-			t.Fatal(err)
+	t.Run("case 1", func(bench *testing.B) {
+		bench.ResetTimer()
+		bench.ReportAllocs()
+		for i := 0; i < bench.N; i++ {
+			if _, err := ExpandPostings(Intersect(i1, i2, i3, i4)); err != nil {
+				bench.Fatal(err)
+			}
 		}
+	})
+
+	a = a[:0]
+	b = b[:0]
+	c = c[:0]
+	d = d[:0]
+	for i := 0; i < 12500000; i++ {
+		a = append(a, uint64(i))
 	}
+	for i := 7500000; i < 12500000; i++ {
+		b = append(b, uint64(i))
+	}
+	for i := 9000000; i < 20000000; i++ {
+		c = append(c, uint64(i))
+	}
+	for i := 10000000; i < 12000000; i++ {
+		d = append(d, uint64(i))
+	}
+	i1 = newListPostings(a...)
+	i2 = newListPostings(b...)
+	i3 = newListPostings(c...)
+	i4 = newListPostings(d...)
+	t.Run("case 2", func(bench *testing.B) {
+		bench.ResetTimer()
+		bench.ReportAllocs()
+		for i := 0; i < bench.N; i++ {
+			if _, err := ExpandPostings(Intersect(i1, i2, i3, i4)); err != nil {
+				bench.Fatal(err)
+			}
+		}
+	})
 }
 
 func TestMultiMerge(t *testing.T) {

--- a/index/postings_test.go
+++ b/index/postings_test.go
@@ -221,30 +221,30 @@ func TestMultiIntersect(t *testing.T) {
 }
 
 func BenchmarkIntersect(t *testing.B) {
-	var a, b, c, d []uint64
+	t.Run("LongPostings1", func(bench *testing.B) {
+		var a, b, c, d []uint64
 
-	for i := 0; i < 10000000; i += 2 {
-		a = append(a, uint64(i))
-	}
-	for i := 5000000; i < 5000100; i += 4 {
-		b = append(b, uint64(i))
-	}
-	for i := 5090000; i < 5090600; i += 4 {
-		b = append(b, uint64(i))
-	}
-	for i := 4990000; i < 5100000; i++ {
-		c = append(c, uint64(i))
-	}
-	for i := 4000000; i < 6000000; i++ {
-		d = append(d, uint64(i))
-	}
+		for i := 0; i < 10000000; i += 2 {
+			a = append(a, uint64(i))
+		}
+		for i := 5000000; i < 5000100; i += 4 {
+			b = append(b, uint64(i))
+		}
+		for i := 5090000; i < 5090600; i += 4 {
+			b = append(b, uint64(i))
+		}
+		for i := 4990000; i < 5100000; i++ {
+			c = append(c, uint64(i))
+		}
+		for i := 4000000; i < 6000000; i++ {
+			d = append(d, uint64(i))
+		}
 
-	i1 := newListPostings(a...)
-	i2 := newListPostings(b...)
-	i3 := newListPostings(c...)
-	i4 := newListPostings(d...)
+		i1 := newListPostings(a...)
+		i2 := newListPostings(b...)
+		i3 := newListPostings(c...)
+		i4 := newListPostings(d...)
 
-	t.Run("case 1", func(bench *testing.B) {
 		bench.ResetTimer()
 		bench.ReportAllocs()
 		for i := 0; i < bench.N; i++ {
@@ -254,31 +254,53 @@ func BenchmarkIntersect(t *testing.B) {
 		}
 	})
 
-	a = a[:0]
-	b = b[:0]
-	c = c[:0]
-	d = d[:0]
-	for i := 0; i < 12500000; i++ {
-		a = append(a, uint64(i))
-	}
-	for i := 7500000; i < 12500000; i++ {
-		b = append(b, uint64(i))
-	}
-	for i := 9000000; i < 20000000; i++ {
-		c = append(c, uint64(i))
-	}
-	for i := 10000000; i < 12000000; i++ {
-		d = append(d, uint64(i))
-	}
-	i1 = newListPostings(a...)
-	i2 = newListPostings(b...)
-	i3 = newListPostings(c...)
-	i4 = newListPostings(d...)
-	t.Run("case 2", func(bench *testing.B) {
+	t.Run("LongPostings2", func(bench *testing.B) {
+		var a, b, c, d []uint64
+
+		for i := 0; i < 12500000; i++ {
+			a = append(a, uint64(i))
+		}
+		for i := 7500000; i < 12500000; i++ {
+			b = append(b, uint64(i))
+		}
+		for i := 9000000; i < 20000000; i++ {
+			c = append(c, uint64(i))
+		}
+		for i := 10000000; i < 12000000; i++ {
+			d = append(d, uint64(i))
+		}
+
+		i1 := newListPostings(a...)
+		i2 := newListPostings(b...)
+		i3 := newListPostings(c...)
+		i4 := newListPostings(d...)
+
 		bench.ResetTimer()
 		bench.ReportAllocs()
 		for i := 0; i < bench.N; i++ {
 			if _, err := ExpandPostings(Intersect(i1, i2, i3, i4)); err != nil {
+				bench.Fatal(err)
+			}
+		}
+	})
+
+	// Many matchers(k >> n).
+	t.Run("ManyPostings", func(bench *testing.B) {
+		var its []Postings
+
+		// 100000 matchers(k=100000).
+		for i := 0; i < 100000; i++ {
+			var temp []uint64
+			for j := 1; j < 100; j++ {
+				temp = append(temp, uint64(j))
+			}
+			its = append(its, newListPostings(temp...))
+		}
+
+		bench.ResetTimer()
+		bench.ReportAllocs()
+		for i := 0; i < bench.N; i++ {
+			if _, err := ExpandPostings(Intersect(its...)); err != nil {
 				bench.Fatal(err)
 			}
 		}


### PR DESCRIPTION
Tree-like recursive methods in the current implementation of Intersect() can cause unnecessary Seek().

**An example**
Suppose there are 4 postings [1,2,3,4,5], [3,4, 5], [5,6,7,8], [5, 8].
Calling func Intersect(), p1 and p2 will form an intersectPostings, p3 and p4 will form an intersectPostings. The steps are as follows.
1. Next() for ip1
1.1 Next() for p1 → 1
1.2 Seek(1) for p2 → 3
1.3 Seek(3) for p1 → 3
2. Seek(3) for ip2
2.1 Seek(3) for p3 → 5
2.2 Seek(3) for p4 → 5
3. Seek(5) for ip1
3.1 Seek(5) for p1 → 5
3.2 Seek(5) for p2 → 5
4. Next() for ip1

There are unnecessary Seek(3).
If not use recursive func Intersect(), instead manage all together in an array and Seek() the max value each time. The steps are as follows.
1. Next() for p1, p2, p3, p4 → max=5
2. Seek(5) for p1 → 5
3. Seek(5) for p2 → 5
4. Next() for p1, p2, p3, p4 → finish

**Benchmark**
```
benchmark                       old ns/op     new ns/op     delta
BenchmarkIntersect/case_1-8     199           100           -49.75%
BenchmarkIntersect/case_2-8     195           95.6          -50.97%

benchmark                       old allocs     new allocs     delta
BenchmarkIntersect/case_1-8     4              2              -50.00%
BenchmarkIntersect/case_2-8     4              2              -50.00%

benchmark                       old bytes     new bytes     delta
BenchmarkIntersect/case_1-8     208           96            -53.85%
BenchmarkIntersect/case_2-8     208           96            -53.85%
```