### PR TITLE
fix two benchmarks

### DIFF
--- a/compact_test.go
+++ b/compact_test.go
@@ -800,11 +800,11 @@ func BenchmarkCompaction(b *testing.B) {
 			compactionType: "normal",
 		},
 		{
-			ranges:         [][2]int64{{0, 10000}, {20000, 30000}, {40000, 50000}, {60000, 70000}},
+			ranges:         [][2]int64{{0, 2000}, {3000, 5000}, {6000, 8000}, {9000, 11000}},
 			compactionType: "normal",
 		},
 		{
-			ranges:         [][2]int64{{0, 100000}, {200000, 300000}, {400000, 500000}, {600000, 700000}},
+			ranges:         [][2]int64{{0, 5000}, {6000, 11000}, {12000, 17000}, {18000, 23000}},
 			compactionType: "normal",
 		},
 		// 40% overlaps.
@@ -817,11 +817,11 @@ func BenchmarkCompaction(b *testing.B) {
 			compactionType: "vertical",
 		},
 		{
-			ranges:         [][2]int64{{0, 10000}, {6000, 16000}, {12000, 22000}, {18000, 28000}},
+			ranges:         [][2]int64{{0, 2000}, {1200, 3200}, {2400, 4400}, {3600, 5600}},
 			compactionType: "vertical",
 		},
 		{
-			ranges:         [][2]int64{{0, 100000}, {60000, 160000}, {120000, 220000}, {180000, 280000}},
+			ranges:         [][2]int64{{0, 5000}, {3000, 8000}, {6000, 11000}, {9000, 14000}},
 			compactionType: "vertical",
 		},
 	}

--- a/head_test.go
+++ b/head_test.go
@@ -34,7 +34,11 @@ import (
 )
 
 func BenchmarkCreateSeries(b *testing.B) {
-	lbls, err := labels.ReadLabels(filepath.Join("testdata", "20kseries.json"), b.N)
+	n := b.N
+	if n > 20000 {
+		n = 20000
+	}
+	lbls, err := labels.ReadLabels(filepath.Join("testdata", "20kseries.json"), n)
 	testutil.Ok(b, err)
 
 	h, err := NewHead(nil, nil, nil, 10000)

--- a/head_test.go
+++ b/head_test.go
@@ -19,7 +19,6 @@ import (
 	"math/rand"
 	"os"
 	"path"
-	"path/filepath"
 	"sort"
 	"testing"
 
@@ -34,12 +33,7 @@ import (
 )
 
 func BenchmarkCreateSeries(b *testing.B) {
-	n := b.N
-	if n > 20000 {
-		n = 20000
-	}
-	lbls, err := labels.ReadLabels(filepath.Join("testdata", "20kseries.json"), n)
-	testutil.Ok(b, err)
+	series := genSeries(b.N, 10, 0, 0)
 
 	h, err := NewHead(nil, nil, nil, 10000)
 	testutil.Ok(b, err)
@@ -48,8 +42,8 @@ func BenchmarkCreateSeries(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 
-	for _, l := range lbls {
-		h.getOrCreate(l.Hash(), l)
+	for _, s := range series {
+		h.getOrCreate(s.Labels().Hash(), s.Labels())
 	}
 }
 


### PR DESCRIPTION
- BenchmarkCompaction will always OOM even in Prometheus test machine
- BenchmarkCreateSeries has a high probability to fail

<!--
    Don't forget!
    
    - Most PRs would require a CHANGELOG entry.
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->