### PR TITLE
fileutil.Replace - remove destination only when a directory.

### DIFF
--- a/fileutil/fileutil.go
+++ b/fileutil/fileutil.go
@@ -128,9 +128,20 @@ func Rename(from, to string) error {
 // Replace moves a file or directory to a new location and deletes any previous data.
 // It is not atomic.
 func Replace(from, to string) error {
-	if err := os.RemoveAll(to); err != nil {
-		return err
+	// Remove destionation only if it is a dir.
+	// Otherwise os.Rename replaces the destination file and is atomic.
+	{
+		f, err := os.Stat(to)
+		if err != nil {
+			return err
+		}
+		if f.IsDir() {
+			if err := os.RemoveAll(to); err != nil {
+				return err
+			}
+		}
 	}
+
 	if err := os.Rename(from, to); err != nil {
 		return err
 	}

--- a/fileutil/fileutil.go
+++ b/fileutil/fileutil.go
@@ -128,16 +128,15 @@ func Rename(from, to string) error {
 // Replace moves a file or directory to a new location and deletes any previous data.
 // It is not atomic.
 func Replace(from, to string) error {
-	// Remove destionation only if it is a dir.
-	// Otherwise os.Rename replaces the destination file and is atomic.
+	// Remove destination only if it is a dir otherwise leave it to os.Rename
+	// as it replaces the destination when it is file and is atomic.
 	{
 		f, err := os.Stat(to)
-		if err != nil {
-			return err
-		}
-		if f.IsDir() {
-			if err := os.RemoveAll(to); err != nil {
-				return err
+		if !os.IsNotExist(err) {
+			if err == nil && f.IsDir() {
+				if err := os.RemoveAll(to); err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/fileutil/fileutil.go
+++ b/fileutil/fileutil.go
@@ -129,7 +129,7 @@ func Rename(from, to string) error {
 // It is not atomic.
 func Replace(from, to string) error {
 	// Remove destination only if it is a dir otherwise leave it to os.Rename
-	// as it replaces the destination when it is file and is atomic.
+	// as it replaces the destination file and is atomic.
 	{
 		f, err := os.Stat(to)
 		if !os.IsNotExist(err) {


### PR DESCRIPTION
In cases where a rename fails the `fileutil.Replace` would delete the
source files/folder.

There is no easy way to make directory renaming atomic, but for files
`os.Rename` is atomic and replaced the destination file so there is no
need to remove the destination file explicitly.

this was caught while working on the FS errors injections on rename in https://github.com/prometheus/tsdb/pull/583 with `block.Delete` . Before this change a failure during a rename would cause deleting the source meta and tombstone files.