### PR TITLE
refactor block size calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 ## master / unreleased
  - [FEATURE] Provide option to compress WAL records using Snappy. [#609](https://github.com/prometheus/tsdb/pull/609)
  - [BUGFIX] Re-calculate block size when calling `block.Delete`.
-    - as part of this the `BlockStats` now includes size information for chunks,index,tombstone,meta separately.
-
+ - [CHANGE] `BlockStats` no longer holds size information and this is kept in memory.
 
 ## 0.8.0
  - [BUGFIX] Calling `Close` more than once on a querier returns an error instead of a panic.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## master / unreleased
  - [FEATURE] Provide option to compress WAL records using Snappy. [#609](https://github.com/prometheus/tsdb/pull/609)
  - [BUGFIX] Re-calculate block size when calling `block.Delete`.
- - [CHANGE] `BlockStats` no longer holds size information and this is kept in memory.
+- [CHANGE] The meta file `BlockStats` no longer holds size information. This is now dynamically calculated and kept in memory. It also includes the meta file size which was not included before.
 
 ## 0.8.0
  - [BUGFIX] Calling `Close` more than once on a querier returns an error instead of a panic.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## master / unreleased
  - [FEATURE] Provide option to compress WAL records using Snappy. [#609](https://github.com/prometheus/tsdb/pull/609)
+ - [BUGFIX] Re-calculate block size when calling `block.Delete`.
+    - as part of this the `BlockStats` now includes size information for chunks,index,tombstone,meta separately.
+
 
 ## 0.8.0
  - [BUGFIX] Calling `Close` more than once on a querier returns an error instead of a panic.

--- a/block.go
+++ b/block.go
@@ -429,8 +429,11 @@ func (pb *Block) GetSymbolTableSize() uint64 {
 func (pb *Block) setCompactionFailed() error {
 	pb.meta.Compaction.Failed = true
 	n, err := writeMetaFile(pb.logger, pb.dir, &pb.meta)
+	if err != nil {
+		return err
+	}
 	pb.numBytesMeta = n
-	return err
+	return nil
 }
 
 type blockIndexReader struct {

--- a/block.go
+++ b/block.go
@@ -240,8 +240,7 @@ func writeMetaFile(logger log.Logger, dir string, meta *BlockMeta) error {
 
 	// The meta file is within a block so
 	// its size needs to be calcualted and set upfront.
-	err := setMetaFileSize(meta)
-	if err != nil {
+	if err := setMetaFileSize(meta); err != nil {
 		return err
 	}
 
@@ -265,8 +264,7 @@ func writeMetaFile(logger log.Logger, dir string, meta *BlockMeta) error {
 	}
 
 	var merr tsdb_errors.MultiError
-	_, err = f.Write(jsonMeta)
-	if err != nil {
+	if _, err = f.Write(jsonMeta); err != nil {
 		merr.Add(err)
 		merr.Add(f.Close())
 		return merr.Err()
@@ -275,6 +273,7 @@ func writeMetaFile(logger log.Logger, dir string, meta *BlockMeta) error {
 	// Force the kernel to persist the file on disk to avoid data loss if the host crashes.
 	if err := f.Sync(); err != nil {
 		merr.Add(err)
+		merr.Add(f.Close())
 		return merr.Err()
 	}
 	if err := f.Close(); err != nil {
@@ -285,7 +284,6 @@ func writeMetaFile(logger log.Logger, dir string, meta *BlockMeta) error {
 
 // setMetaFileSize calculates and set the meta file size.
 func setMetaFileSize(meta *BlockMeta) error {
-
 	jsonMeta, err := json.MarshalIndent(meta, "", "\t")
 	if err != nil {
 		return err

--- a/block.go
+++ b/block.go
@@ -428,7 +428,8 @@ func (pb *Block) GetSymbolTableSize() uint64 {
 
 func (pb *Block) setCompactionFailed() error {
 	pb.meta.Compaction.Failed = true
-	_, err := writeMetaFile(pb.logger, pb.dir, &pb.meta)
+	n, err := writeMetaFile(pb.logger, pb.dir, &pb.meta)
+	pb.numBytesMeta = n
 	return err
 }
 

--- a/block_test.go
+++ b/block_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/prometheus/tsdb/chunks"
+	"github.com/prometheus/tsdb/labels"
 	"github.com/prometheus/tsdb/testutil"
 	"github.com/prometheus/tsdb/tsdbutil"
 )
@@ -147,6 +148,60 @@ func TestCorruptedChunk(t *testing.T) {
 			testutil.Equals(t, test.expErr.Error(), err.Error())
 		})
 	}
+}
+
+// TestBlockSize ensures that the block size is calculated correctly.
+func TestBlockSize(t *testing.T) {
+	tmpdir, err := ioutil.TempDir("", "test_blockSize")
+	testutil.Ok(t, err)
+	defer func() {
+		testutil.Ok(t, os.RemoveAll(tmpdir))
+	}()
+
+	var (
+		blockInit    *Block
+		expSizeInit  int64
+		blockDirInit string
+	)
+	// Create a block and compare the reported size vs actual disk size.
+	{
+		blockDirInit = createBlock(t, tmpdir, genSeries(10, 1, 1, 100))
+		blockInit, err = OpenBlock(nil, blockDirInit, nil)
+		testutil.Ok(t, err)
+		defer func() {
+			testutil.Ok(t, blockInit.Close())
+		}()
+		expSizeInit = blockInit.Size()
+		actSizeInit, err := testutil.DirSize(blockInit.Dir())
+		testutil.Ok(t, err)
+		testutil.Equals(t, expSizeInit, actSizeInit)
+	}
+
+	// Delete some series and check the sizes again.
+	{
+		testutil.Ok(t, blockInit.Delete(1, 10, labels.NewMustRegexpMatcher("", ".*")))
+		expAfterDelete := blockInit.Size()
+		testutil.Assert(t, expAfterDelete > expSizeInit, "after a delete the block size should be bigger as the tombstone file should grow %v > %v", expAfterDelete, expSizeInit)
+		actAfterDelete, err := testutil.DirSize(blockDirInit)
+		testutil.Ok(t, err)
+		testutil.Equals(t, expAfterDelete, actAfterDelete, "after a delete reported block size doesn't match actual disk size")
+
+		c, err := NewLeveledCompactor(context.Background(), nil, log.NewNopLogger(), []int64{0}, nil)
+		testutil.Ok(t, err)
+		blockDirAfterCompact, err := c.Compact(tmpdir, []string{blockInit.Dir()}, nil)
+		testutil.Ok(t, err)
+		blockAfterCompact, err := OpenBlock(nil, filepath.Join(tmpdir, blockDirAfterCompact.String()), nil)
+		testutil.Ok(t, err)
+		defer func() {
+			testutil.Ok(t, blockAfterCompact.Close())
+		}()
+		expAfterCompact := blockAfterCompact.Size()
+		actAfterCompact, err := testutil.DirSize(blockAfterCompact.Dir())
+		testutil.Ok(t, err)
+		testutil.Assert(t, actAfterDelete > actAfterCompact, "after a delete and compaction the block size should be smaller %v,%v", actAfterDelete, actAfterCompact)
+		testutil.Equals(t, expAfterCompact, actAfterCompact, "after a delete and compaction reported block size doesn't match actual disk size")
+	}
+
 }
 
 // createBlock creates a block with given set of series and returns its dir.

--- a/compact.go
+++ b/compact.go
@@ -420,12 +420,14 @@ func (c *LeveledCompactor) Compact(dest string, dirs []string, open []*Block) (u
 		if meta.Stats.NumSamples == 0 {
 			for _, b := range bs {
 				b.meta.Compaction.Deletable = true
-				if _, err = writeMetaFile(c.logger, b.dir, &b.meta); err != nil {
+				n, err := writeMetaFile(c.logger, b.dir, &b.meta)
+				if err != nil {
 					level.Error(c.logger).Log(
 						"msg", "Failed to write 'Deletable' to meta file after compaction",
 						"ulid", b.meta.ULID,
 					)
 				}
+				b.numBytesMeta = n
 			}
 			uid = ulid.ULID{}
 			level.Info(c.logger).Log(

--- a/compact.go
+++ b/compact.go
@@ -178,7 +178,7 @@ func (c *LeveledCompactor) Plan(dir string) ([]string, error) {
 
 	var dms []dirMeta
 	for _, dir := range dirs {
-		meta, err := readMetaFile(dir)
+		meta, _, err := readMetaFile(dir)
 		if err != nil {
 			return nil, err
 		}
@@ -380,7 +380,7 @@ func (c *LeveledCompactor) Compact(dest string, dirs []string, open []*Block) (u
 	start := time.Now()
 
 	for _, d := range dirs {
-		meta, err := readMetaFile(d)
+		meta, _, err := readMetaFile(d)
 		if err != nil {
 			return uid, err
 		}
@@ -420,7 +420,7 @@ func (c *LeveledCompactor) Compact(dest string, dirs []string, open []*Block) (u
 		if meta.Stats.NumSamples == 0 {
 			for _, b := range bs {
 				b.meta.Compaction.Deletable = true
-				if err = writeMetaFile(c.logger, b.dir, &b.meta); err != nil {
+				if _, err = writeMetaFile(c.logger, b.dir, &b.meta); err != nil {
 					level.Error(c.logger).Log(
 						"msg", "Failed to write 'Deletable' to meta file after compaction",
 						"ulid", b.meta.ULID,
@@ -600,7 +600,7 @@ func (c *LeveledCompactor) write(dest string, meta *BlockMeta, blocks ...BlockRe
 		return nil
 	}
 
-	if err = writeMetaFile(c.logger, tmp, meta); err != nil {
+	if _, err = writeMetaFile(c.logger, tmp, meta); err != nil {
 		return errors.Wrap(err, "write merged meta")
 	}
 

--- a/compact.go
+++ b/compact.go
@@ -605,7 +605,7 @@ func (c *LeveledCompactor) write(dest string, meta *BlockMeta, blocks ...BlockRe
 	}
 
 	// Create an empty tombstones file.
-	if err := writeTombstoneFile(c.logger, tmp, newMemTombstones()); err != nil {
+	if _, err := writeTombstoneFile(c.logger, tmp, newMemTombstones()); err != nil {
 		return errors.Wrap(err, "write new tombstones file")
 	}
 

--- a/db.go
+++ b/db.go
@@ -629,7 +629,7 @@ func (db *DB) openBlocks() (blocks []*Block, corrupted map[ulid.ULID]error, err 
 
 	corrupted = make(map[ulid.ULID]error)
 	for _, dir := range dirs {
-		meta, err := readMetaFile(dir)
+		meta, _, err := readMetaFile(dir)
 		if err != nil {
 			level.Error(db.logger).Log("msg", "not a block dir", "dir", dir)
 			continue

--- a/repair.go
+++ b/repair.go
@@ -109,7 +109,7 @@ func repairBadIndexVersion(logger log.Logger, dir string) error {
 		}
 		// Reset version of meta.json to 1.
 		meta.Version = 1
-		if err := writeMetaFile(logger, d, meta); err != nil {
+		if _, err := writeMetaFile(logger, d, meta); err != nil {
 			return wrapErr(err, d)
 		}
 	}

--- a/repair_test.go
+++ b/repair_test.go
@@ -65,7 +65,7 @@ func TestRepairBadIndexVersion(t *testing.T) {
 
 	// Check the current db.
 	// In its current state, lookups should fail with the fixed code.
-	_, err := readMetaFile(dbDir)
+	_, _, err := readMetaFile(dbDir)
 	testutil.NotOk(t, err)
 
 	// Touch chunks dir in block.
@@ -121,7 +121,7 @@ func TestRepairBadIndexVersion(t *testing.T) {
 		{{"a", "2"}, {"b", "1"}},
 	}, res)
 
-	meta, err := readMetaFile(tmpDbDir)
+	meta, _, err := readMetaFile(tmpDbDir)
 	testutil.Ok(t, err)
 	testutil.Assert(t, meta.Version == 1, "unexpected meta version %d", meta.Version)
 }

--- a/tombstones.go
+++ b/tombstones.go
@@ -104,7 +104,7 @@ func writeTombstoneFile(logger log.Logger, dir string, tr TombstoneReader) (int6
 		}
 		return nil
 	}); err != nil {
-		return int64(n), fmt.Errorf("error writing tombstones: %v", err)
+		return 0, fmt.Errorf("error writing tombstones: %v", err)
 	}
 
 	n, err = f.Write(hash.Sum(nil))

--- a/tombstones_test.go
+++ b/tombstones_test.go
@@ -47,7 +47,8 @@ func TestWriteAndReadbackTombStones(t *testing.T) {
 		stones.addInterval(ref, dranges...)
 	}
 
-	testutil.Ok(t, writeTombstoneFile(log.NewNopLogger(), tmpdir, stones))
+	_, err := writeTombstoneFile(log.NewNopLogger(), tmpdir, stones)
+	testutil.Ok(t, err)
 
 	restr, _, err := readTombstones(tmpdir)
 	testutil.Ok(t, err)


### PR DESCRIPTION
It now includes the size of the meta file itself as well for a more
correct block size.
It fixes a bug where the size didn't change when calling block.Delete.
Adds a dedicated test to ensure correct block sizes.
To allow opening the db in a read only mode it ensures the meta file is
not rewritten when the block size hasn't change .

Signed-off-by: Krasi Georgiev <8903888+krasi-georgiev@users.noreply.github.com>