### PR TITLE
Reuse Chunk Iterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Master / unreleased
 
- - [FEATURE] `XORIterator` gets a `Reset` method.
+ - [FEATURE] `chunckenc.Chunk.Iterator` method now takes a `chunckenc.Iterator` interface as an argument for reuse.
 
 ## 0.9.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## master / unreleased
  - [FEATURE] Provide option to compress WAL records using Snappy. [#609](https://github.com/prometheus/tsdb/pull/609)
  - [BUGFIX] Re-calculate block size when calling `block.Delete`.
-- [CHANGE] The meta file `BlockStats` no longer holds size information. This is now dynamically calculated and kept in memory. It also includes the meta file size which was not included before.
+ - [CHANGE] The meta file `BlockStats` no longer holds size information. This is now dynamically calculated and kept in memory. It also includes the meta file size which was not included before.
+ - [FEATURE] `XORIterator` gets a `Reset` method.
 
 ## 0.8.0
  - [BUGFIX] Calling `Close` more than once on a querier returns an error instead of a panic.

--- a/chunkenc/chunk.go
+++ b/chunkenc/chunk.go
@@ -44,7 +44,10 @@ type Chunk interface {
 	Bytes() []byte
 	Encoding() Encoding
 	Appender() (Appender, error)
-	Iterator() Iterator
+	// The iterator passed as argument is for re-use.
+	// Depending on implementation, the iterator can
+	// be re-used or a new iterator can be allocated.
+	Iterator(Iterator) Iterator
 	NumSamples() int
 }
 

--- a/chunkenc/chunk.go
+++ b/chunkenc/chunk.go
@@ -58,7 +58,6 @@ type Iterator interface {
 	At() (int64, float64)
 	Err() error
 	Next() bool
-	Reset([]byte) bool
 }
 
 // NewNopIterator returns a new chunk iterator that does not hold any data.
@@ -71,7 +70,6 @@ type nopIterator struct{}
 func (nopIterator) At() (int64, float64) { return 0, 0 }
 func (nopIterator) Next() bool           { return false }
 func (nopIterator) Err() error           { return nil }
-func (nopIterator) Reset(_ []byte) bool  { return false }
 
 // Pool is used to create and reuse chunk references to avoid allocations.
 type Pool interface {

--- a/chunkenc/chunk.go
+++ b/chunkenc/chunk.go
@@ -58,6 +58,7 @@ type Iterator interface {
 	At() (int64, float64)
 	Err() error
 	Next() bool
+	Reset([]byte) bool
 }
 
 // NewNopIterator returns a new chunk iterator that does not hold any data.
@@ -70,6 +71,7 @@ type nopIterator struct{}
 func (nopIterator) At() (int64, float64) { return 0, 0 }
 func (nopIterator) Next() bool           { return false }
 func (nopIterator) Err() error           { return nil }
+func (nopIterator) Reset(_ []byte) bool  { return false }
 
 // Pool is used to create and reuse chunk references to avoid allocations.
 type Pool interface {

--- a/chunkenc/chunk_test.go
+++ b/chunkenc/chunk_test.go
@@ -77,7 +77,7 @@ func testChunk(c Chunk) error {
 		// fmt.Println("appended", len(c.Bytes()), c.Bytes())
 	}
 
-	it := c.Iterator()
+	it := c.Iterator(nil)
 	var res []pair
 	for it.Next() {
 		ts, v := it.At()
@@ -133,9 +133,10 @@ func benchmarkIterator(b *testing.B, newChunk func() Chunk) {
 
 	res := make([]float64, 0, 1024)
 
+	var it Iterator
 	for i := 0; i < len(chunks); i++ {
 		c := chunks[i]
-		it := c.Iterator()
+		it := c.Iterator(it)
 
 		for it.Next() {
 			_, v := it.At()

--- a/chunkenc/xor.go
+++ b/chunkenc/xor.go
@@ -243,6 +243,21 @@ func (it *xorIterator) Err() error {
 	return it.err
 }
 
+func (it *xorIterator) Reset(b []byte) bool {
+	it.br = newBReader(b[2:])
+	it.numTotal = binary.BigEndian.Uint16(b)
+
+	it.numRead = 0
+	it.t = 0
+	it.val = 0
+	it.leading = 0
+	it.trailing = 0
+	it.tDelta = 0
+	it.err = nil
+
+	return true
+}
+
 func (it *xorIterator) Next() bool {
 	if it.err != nil || it.numRead == it.numTotal {
 		return false

--- a/chunkenc/xor.go
+++ b/chunkenc/xor.go
@@ -111,6 +111,8 @@ func (c *XORChunk) iterator(it Iterator) *xorIterator {
 		return xorIter
 	}
 	return &xorIterator{
+		// The first 2 bytes contain chunk headers.
+		// We skip that for actual samples.
 		br:       newBReader(c.b.bytes()[2:]),
 		numTotal: binary.BigEndian.Uint16(c.b.bytes()),
 	}
@@ -248,6 +250,8 @@ func (it *xorIterator) Err() error {
 }
 
 func (it *xorIterator) Reset(b []byte) {
+	// The first 2 bytes contain chunk headers.
+	// We skip that for actual samples.
 	it.br = newBReader(b[2:])
 	it.numTotal = binary.BigEndian.Uint16(b)
 

--- a/chunks/chunks.go
+++ b/chunks/chunks.go
@@ -245,8 +245,8 @@ func MergeChunks(a, b chunkenc.Chunk) (*chunkenc.XORChunk, error) {
 	if err != nil {
 		return nil, err
 	}
-	ait := a.Iterator()
-	bit := b.Iterator()
+	ait := a.Iterator(nil)
+	bit := b.Iterator(nil)
 	aok, bok := ait.Next(), bit.Next()
 	for aok && bok {
 		at, av := ait.At()

--- a/compact.go
+++ b/compact.go
@@ -773,6 +773,7 @@ func (c *LeveledCompactor) populateBlock(blocks []BlockReader, meta *BlockMeta, 
 					return err
 				}
 
+				// TODO(codesome): Use XORIterator.Reset(), and maybe also re-use this deletedIterator.
 				it := &deletedIterator{it: chk.Chunk.Iterator(), intervals: dranges}
 				for it.Next() {
 					ts, v := it.At()

--- a/compact.go
+++ b/compact.go
@@ -736,6 +736,7 @@ func (c *LeveledCompactor) populateBlock(blocks []BlockReader, meta *BlockMeta, 
 		return errors.Wrap(err, "add symbols")
 	}
 
+	delIter := &deletedIterator{}
 	for set.Next() {
 		select {
 		case <-c.ctx.Done():
@@ -788,18 +789,18 @@ func (c *LeveledCompactor) populateBlock(blocks []BlockReader, meta *BlockMeta, 
 					return err
 				}
 
-				// TODO(codesome): Use XORIterator.Reset(), and maybe also re-use this deletedIterator.
-				it := &deletedIterator{it: chk.Chunk.Iterator(), intervals: dranges}
+				delIter.it = chk.Chunk.Iterator(delIter.it)
+				delIter.intervals = dranges
 
 				var (
 					t int64
 					v float64
 				)
-				for it.Next() {
-					t, v = it.At()
+				for delIter.Next() {
+					t, v = delIter.At()
 					app.Append(t, v)
 				}
-				if err := it.Err(); err != nil {
+				if err := delIter.Err(); err != nil {
 					return errors.Wrap(err, "iterate chunk while re-encoding")
 				}
 

--- a/head.go
+++ b/head.go
@@ -1185,9 +1185,9 @@ type safeChunk struct {
 	cid int
 }
 
-func (c *safeChunk) Iterator() chunkenc.Iterator {
+func (c *safeChunk) Iterator(reuseIter chunkenc.Iterator) chunkenc.Iterator {
 	c.s.Lock()
-	it := c.s.iterator(c.cid)
+	it := c.s.iterator(c.cid, reuseIter)
 	c.s.Unlock()
 	return it
 }
@@ -1739,7 +1739,7 @@ func computeChunkEndTime(start, cur, max int64) int64 {
 	return start + (max-start)/a
 }
 
-func (s *memSeries) iterator(id int) chunkenc.Iterator {
+func (s *memSeries) iterator(id int, it chunkenc.Iterator) chunkenc.Iterator {
 	c := s.chunk(id)
 	// TODO(fabxc): Work around! A querier may have retrieved a pointer to a series' chunk,
 	// which got then garbage collected before it got accessed.
@@ -1749,17 +1749,22 @@ func (s *memSeries) iterator(id int) chunkenc.Iterator {
 	}
 
 	if id-s.firstChunkID < len(s.chunks)-1 {
-		return c.chunk.Iterator()
+		return c.chunk.Iterator(it)
 	}
 	// Serve the last 4 samples for the last chunk from the sample buffer
 	// as their compressed bytes may be mutated by added samples.
-	it := &memSafeIterator{
-		Iterator: c.chunk.Iterator(),
+	if msIter, ok := it.(*memSafeIterator); ok {
+		msIter.Iterator = c.chunk.Iterator(nil)
+		msIter.i = -1
+		msIter.total = c.chunk.NumSamples()
+		msIter.buf = s.sampleBuf
+	}
+	return &memSafeIterator{
+		Iterator: c.chunk.Iterator(it),
 		i:        -1,
 		total:    c.chunk.NumSamples(),
 		buf:      s.sampleBuf,
 	}
-	return it
 }
 
 func (s *memSeries) head() *memChunk {

--- a/head.go
+++ b/head.go
@@ -1754,10 +1754,11 @@ func (s *memSeries) iterator(id int, it chunkenc.Iterator) chunkenc.Iterator {
 	// Serve the last 4 samples for the last chunk from the sample buffer
 	// as their compressed bytes may be mutated by added samples.
 	if msIter, ok := it.(*memSafeIterator); ok {
-		msIter.Iterator = c.chunk.Iterator(nil)
+		msIter.Iterator = c.chunk.Iterator(msIter.Iterator)
 		msIter.i = -1
 		msIter.total = c.chunk.NumSamples()
 		msIter.buf = s.sampleBuf
+		return msIter
 	}
 	return &memSafeIterator{
 		Iterator: c.chunk.Iterator(it),

--- a/head_test.go
+++ b/head_test.go
@@ -159,9 +159,9 @@ func TestHead_ReadWAL(t *testing.T) {
 				testutil.Ok(t, c.Err())
 				return x
 			}
-			testutil.Equals(t, []sample{{100, 2}, {101, 5}}, expandChunk(s10.iterator(0)))
-			testutil.Equals(t, []sample{{101, 6}}, expandChunk(s50.iterator(0)))
-			testutil.Equals(t, []sample{{100, 3}, {101, 7}}, expandChunk(s100.iterator(0)))
+			testutil.Equals(t, []sample{{100, 2}, {101, 5}}, expandChunk(s10.iterator(0, nil)))
+			testutil.Equals(t, []sample{{101, 6}}, expandChunk(s50.iterator(0, nil)))
+			testutil.Equals(t, []sample{{100, 3}, {101, 7}}, expandChunk(s100.iterator(0, nil)))
 		})
 	}
 }
@@ -313,11 +313,11 @@ func TestMemSeries_truncateChunks(t *testing.T) {
 
 	// Validate that the series' sample buffer is applied correctly to the last chunk
 	// after truncation.
-	it1 := s.iterator(s.chunkID(len(s.chunks) - 1))
+	it1 := s.iterator(s.chunkID(len(s.chunks)-1), nil)
 	_, ok := it1.(*memSafeIterator)
 	testutil.Assert(t, ok == true, "")
 
-	it2 := s.iterator(s.chunkID(len(s.chunks) - 2))
+	it2 := s.iterator(s.chunkID(len(s.chunks)-2), nil)
 	_, ok = it2.(*memSafeIterator)
 	testutil.Assert(t, ok == false, "non-last chunk incorrectly wrapped with sample buffer")
 }
@@ -451,10 +451,11 @@ func TestHeadDeleteSimple(t *testing.T) {
 
 						chunkr, err := h.Chunks()
 						testutil.Ok(t, err)
+						var ii chunkenc.Iterator
 						for _, meta := range chkMetas {
 							chk, err := chunkr.Chunk(meta.Ref)
 							testutil.Ok(t, err)
-							ii := chk.Iterator()
+							ii = chk.Iterator(ii)
 							for ii.Next() {
 								t, v := ii.At()
 								actSamples = append(actSamples, sample{t: t, v: v})

--- a/mocks_test.go
+++ b/mocks_test.go
@@ -14,6 +14,7 @@
 package tsdb
 
 import (
+	"github.com/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/tsdb/chunks"
 	"github.com/prometheus/tsdb/index"
 	"github.com/prometheus/tsdb/labels"
@@ -40,10 +41,11 @@ func (m *mockIndexWriter) AddSeries(ref uint64, l labels.Labels, chunks ...chunk
 		i = len(m.series) - 1
 	}
 
+	var iter chunkenc.Iterator
 	for _, chk := range chunks {
 		samples := make([]sample, 0, chk.Chunk.NumSamples())
 
-		iter := chk.Chunk.Iterator()
+		iter = chk.Chunk.Iterator(iter)
 		for iter.Next() {
 			s := sample{}
 			s.t, s.v = iter.At()

--- a/querier.go
+++ b/querier.go
@@ -1169,11 +1169,6 @@ func (it *deletedIterator) At() (int64, float64) {
 	return it.it.At()
 }
 
-func (it *deletedIterator) Reset(_ []byte) bool {
-	// TODO: Implement this. How to reset intervals?
-	return false
-}
-
 func (it *deletedIterator) Next() bool {
 Outer:
 	for it.it.Next() {

--- a/querier.go
+++ b/querier.go
@@ -1169,6 +1169,11 @@ func (it *deletedIterator) At() (int64, float64) {
 	return it.it.At()
 }
 
+func (it *deletedIterator) Reset(_ []byte) bool {
+	// TODO: Implement this. How to reset intervals?
+	return false
+}
+
 func (it *deletedIterator) Next() bool {
 Outer:
 	for it.it.Next() {

--- a/querier.go
+++ b/querier.go
@@ -1060,9 +1060,10 @@ func (it *verticalMergeSeriesIterator) Err() error {
 type chunkSeriesIterator struct {
 	chunks []chunks.Meta
 
-	i       int
-	cur     chunkenc.Iterator
-	bufIter *chunkenc.XORIterator
+	i          int
+	cur        chunkenc.Iterator
+	bufXorIter *chunkenc.XORIterator
+	bufDelIter *deletedIterator
 
 	maxt, mint int64
 
@@ -1085,18 +1086,24 @@ func newChunkSeriesIterator(cs []chunks.Meta, dranges Intervals, mint, maxt int6
 }
 
 func (it *chunkSeriesIterator) resetCurIterator() {
-	if it.bufIter != nil {
-		it.bufIter.Reset(it.chunks[it.i].Chunk.Bytes())
-		it.cur = it.bufIter
+	if it.bufXorIter != nil {
+		it.bufXorIter.Reset(it.chunks[it.i].Chunk.Bytes())
+		it.cur = it.bufXorIter
 	} else {
 		it.cur = it.chunks[it.i].Chunk.Iterator()
 		if xorIter, ok := it.cur.(*chunkenc.XORIterator); ok {
-			it.bufIter = xorIter
+			it.bufXorIter = xorIter
 		}
 	}
-	if len(it.intervals) > 0 {
-		it.cur = &deletedIterator{it: it.cur, intervals: it.intervals}
+	if len(it.intervals) == 0 {
+		return
 	}
+	if it.bufDelIter == nil {
+		it.bufDelIter = &deletedIterator{}
+	}
+	it.bufDelIter.it = it.cur
+	it.bufDelIter.intervals = it.intervals
+	it.cur = it.bufDelIter
 }
 
 func (it *chunkSeriesIterator) Seek(t int64) (ok bool) {

--- a/querier_test.go
+++ b/querier_test.go
@@ -1270,7 +1270,7 @@ func TestDeletedIterator(t *testing.T) {
 
 	for _, c := range cases {
 		i := int64(-1)
-		it := &deletedIterator{it: chk.Iterator(), intervals: c.r[:]}
+		it := &deletedIterator{it: chk.Iterator(nil), intervals: c.r[:]}
 		ranges := c.r[:]
 		for it.Next() {
 			i++


### PR DESCRIPTION
Want feedback if something like this would be acceptable. 

When there are millions of chunks to be parsed for a query, re-using the chunk iterator saves a lot of allocs and in my benchmark in cortex it shed up to `5+s` for a query. (I don't have an exact number of chunks as of now).
