### PR TITLE
Re-use 'keys' in ReadOffsetTable

### DIFF
--- a/index/index.go
+++ b/index/index.go
@@ -781,9 +781,10 @@ func ReadOffsetTable(bs ByteSlice, off uint64, f func([]string, uint64) error) e
 	d := encoding.NewDecbufAt(bs, int(off), castagnoliTable)
 	cnt := d.Be32()
 
+	keys := make([]string, 0, 2)
 	for d.Err() == nil && d.Len() > 0 && cnt > 0 {
 		keyCount := d.Uvarint()
-		keys := make([]string, 0, keyCount)
+		keys = keys[:0]
 
 		for i := 0; i < keyCount; i++ {
 			keys = append(keys, d.UvarintStr())

--- a/index/index.go
+++ b/index/index.go
@@ -781,6 +781,9 @@ func ReadOffsetTable(bs ByteSlice, off uint64, f func([]string, uint64) error) e
 	d := encoding.NewDecbufAt(bs, int(off), castagnoliTable)
 	cnt := d.Be32()
 
+	// The Postings offset table takes only 2 keys per entry (name and value of label),
+	// and the LabelIndices offset table takes only 1 key per entry (a label name).
+	// Hence setting the size to max of both, i.e. 2.
 	keys := make([]string, 0, 2)
 	for d.Err() == nil && d.Len() > 0 && cnt > 0 {
 		keyCount := d.Uvarint()


### PR DESCRIPTION
This is a broken down piece of #627

This saves a whole bunch of allocs when opening a block.

- [ ] Add comment for why the len of `keys` is set to 2