### PR TITLE
Add WAL Size to Retention Size check

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -69,7 +69,7 @@ else
 	GO_BUILD_PLATFORM ?= $(GOHOSTOS)-$(GOHOSTARCH)
 endif
 
-PROMU_VERSION ?= 0.4.0
+PROMU_VERSION ?= 0.5.0
 PROMU_URL     := https://github.com/prometheus/promu/releases/download/v$(PROMU_VERSION)/promu-$(PROMU_VERSION).$(GO_BUILD_PLATFORM).tar.gz
 
 GOLANGCI_LINT :=

--- a/db.go
+++ b/db.go
@@ -704,7 +704,11 @@ func (db *DB) beyondSizeRetention(blocks []*Block) (deleteable map[ulid.ULID]*Bl
 	}
 
 	deleteable = make(map[ulid.ULID]*Block)
-	blocksSize := int64(0)
+	walSize, _ := db.Head().wal.Size()
+
+	// Initializing the size counter with the WAL size,
+	// as that is part of the retention strategy as well.
+	blocksSize := walSize
 	for i, block := range blocks {
 		blocksSize += block.Size()
 		if blocksSize > db.opts.MaxBytes {
@@ -774,13 +778,13 @@ func (o Overlaps) String() string {
 				m.ULID.String(),
 				m.MinTime,
 				m.MaxTime,
-				(time.Duration((m.MaxTime-m.MinTime)/1000)*time.Second).String(),
+				(time.Duration((m.MaxTime-m.MinTime)/1000) * time.Second).String(),
 			))
 		}
 		res = append(res, fmt.Sprintf(
 			"[mint: %d, maxt: %d, range: %s, blocks: %d]: %s",
 			r.Min, r.Max,
-			(time.Duration((r.Max-r.Min)/1000)*time.Second).String(),
+			(time.Duration((r.Max-r.Min)/1000) * time.Second).String(),
 			len(overlaps),
 			strings.Join(groups, ", ")),
 		)

--- a/wal/wal.go
+++ b/wal/wal.go
@@ -834,3 +834,17 @@ func (r *segmentBufReader) Read(b []byte) (n int, err error) {
 	r.buf.Reset(r.segs[r.cur])
 	return n, nil
 }
+
+// Computing size of the WAL.
+// We do this by counting the number of segments currently used by the WAL,
+// and multiplying it by the size of a segment.
+func (w *WAL) Size() (size int64, err error) {
+	first, last, err := w.Segments()
+	if err != nil {
+		return 0, err
+	}
+	if first == -1 || last == -1 {
+		return 0, fmt.Errorf("no segments found in WAL")
+	}
+	return int64((last - first + 1) * w.segmentSize), nil
+}


### PR DESCRIPTION
<!--
    Don't forget!
    
    - Most PRs would require a CHANGELOG entry.
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->
Compute the size of the WAL and use it while calculating if exceeding the max retention size limit.