### PR TITLE
Reuse string buffer in stringTuples.Swap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Master / unreleased
 
+ - [ENHANCEMENT] Reuse string buffer in `stringTuples.Swap` to reduce allocs. #654
+
 ## 0.9.1
 
  - [CHANGE] LiveReader metrics are now injected rather than global.

--- a/index/index.go
+++ b/index/index.go
@@ -951,25 +951,28 @@ func (r *Reader) LabelNames() ([]string, error) {
 type stringTuples struct {
 	length  int      // tuple length
 	entries []string // flattened tuple entries
+	swapBuf []string
 }
 
 func NewStringTuples(entries []string, length int) (*stringTuples, error) {
 	if len(entries)%length != 0 {
 		return nil, errors.Wrap(encoding.ErrInvalidSize, "string tuple list")
 	}
-	return &stringTuples{entries: entries, length: length}, nil
+	return &stringTuples{
+		entries: entries,
+		length:  length,
+		swapBuf: make([]string, length),
+	}, nil
 }
 
 func (t *stringTuples) Len() int                   { return len(t.entries) / t.length }
 func (t *stringTuples) At(i int) ([]string, error) { return t.entries[i : i+t.length], nil }
 
 func (t *stringTuples) Swap(i, j int) {
-	c := make([]string, t.length)
-	copy(c, t.entries[i:i+t.length])
-
+	copy(t.swapBuf, t.entries[i:i+t.length])
 	for k := 0; k < t.length; k++ {
 		t.entries[i+k] = t.entries[j+k]
-		t.entries[j+k] = c[k]
+		t.entries[j+k] = t.swapBuf[k]
 	}
 }
 

--- a/index/index.go
+++ b/index/index.go
@@ -961,7 +961,6 @@ func NewStringTuples(entries []string, length int) (*stringTuples, error) {
 	return &stringTuples{
 		entries: entries,
 		length:  length,
-		swapBuf: make([]string, length),
 	}, nil
 }
 
@@ -969,6 +968,9 @@ func (t *stringTuples) Len() int                   { return len(t.entries) / t.l
 func (t *stringTuples) At(i int) ([]string, error) { return t.entries[i : i+t.length], nil }
 
 func (t *stringTuples) Swap(i, j int) {
+	if t.swapBuf == nil {
+		t.swapBuf = make([]string, t.length)
+	}
 	copy(t.swapBuf, t.entries[i:i+t.length])
 	for k := 0; k < t.length; k++ {
 		t.entries[i+k] = t.entries[j+k]


### PR DESCRIPTION
This is a broken down piece of #627

[Don't merge until Prometheus 2.11 is out]