### PR TITLE
chunks: correct the interface name

### DIFF
--- a/chunks/chunks.go
+++ b/chunks/chunks.go
@@ -366,7 +366,7 @@ func (b realByteSlice) Sub(start, end int) ByteSlice {
 	return b[start:end]
 }
 
-// Reader implements a SeriesReader for a serialized byte stream
+// Reader implements a ChunkReader for a serialized byte stream
 // of series data.
 type Reader struct {
 	bs   []ByteSlice // The underlying bytes holding the encoded series data.


### PR DESCRIPTION
https://github.com/prometheus/tsdb/blob/0fdd93b0b936bcd9aefa67954821961aba16c7b3/chunks/chunks.go#L369-L376

There is no interface `SeriesReader` in the comment but `ChunkReader `

https://github.com/prometheus/tsdb/blob/0fdd93b0b936bcd9aefa67954821961aba16c7b3/block.go#L121-L128

