### PR TITLE
labels: support for removing duplicate labels.

### DIFF
--- a/labels/labels.go
+++ b/labels/labels.go
@@ -150,15 +150,15 @@ func FromStrings(ss ...string) Labels {
 	if len(ss)%2 != 0 {
 		panic("invalid number of strings")
 	}
-	var res Labels
-	for i := 0; i < len(ss); i += 2 {
-		if ss[i+1] != "" {
-			res = append(res, Label{Name: ss[i], Value: ss[i+1]})
+
+	m := make(map[string]string)
+	for i := 0; i+1 < len(ss); i += 2 {
+		if ss[i] != "" && ss[i+1] != "" {
+			m[ss[i]] = ss[i+1]
 		}
 	}
 
-	sort.Sort(res)
-	return res
+	return FromMap(m)
 }
 
 // Compare compares the two label sets.

--- a/labels/labels_test.go
+++ b/labels/labels_test.go
@@ -87,6 +87,34 @@ func TestCompareAndEquals(t *testing.T) {
 	}
 }
 
+func TestFromStrings(t *testing.T) {
+	cases := []struct {
+		ss  []string
+		res Labels
+	}{
+		// one string pair
+		{
+			ss:  []string{"a", "b"},
+			res: Labels{{"a", "b"}},
+		},
+		// two string pair
+		{
+			ss:  []string{"a", "b", "c", "0"},
+			res: Labels{{"a", "b"}, {"c", "0"}},
+		},
+		// repeat string pairs
+		{
+			ss:  []string{"a", "b", "a", "b"},
+			res: Labels{{"a", "b"}},
+		},
+	}
+
+	for _, c := range cases {
+		res := FromStrings(c.ss...)
+		testutil.Equals(t, c.res, res)
+	}
+}
+
 func BenchmarkSliceSort(b *testing.B) {
 	lbls, err := ReadLabels(filepath.Join("..", "testdata", "20kseries.json"), 20000)
 	testutil.Ok(b, err)


### PR DESCRIPTION
It is possible to insert duplicate labels using the `FromStrings` function

https://github.com/prometheus/tsdb/blob/3bc1ea3d7584d67882fd4019d5bd892905966eb2/labels/labels.go#L148-L162

This pr is modified to improve the function based on 'FromMap'