### PR TITLE
add metric for tsdb size retention bytes

### DIFF
--- a/db.go
+++ b/db.go
@@ -157,6 +157,7 @@ type dbMetrics struct {
 	startTime            prometheus.GaugeFunc
 	tombCleanTimer       prometheus.Histogram
 	blocksBytes          prometheus.Gauge
+	maxBytes             prometheus.Gauge
 	sizeRetentionCount   prometheus.Counter
 }
 
@@ -227,6 +228,10 @@ func newDBMetrics(db *DB, r prometheus.Registerer) *dbMetrics {
 		Name: "prometheus_tsdb_storage_blocks_bytes",
 		Help: "The number of bytes that are currently used for local storage by all blocks.",
 	})
+	m.maxBytes = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "prometheus_tsdb_retention_limit_bytes",
+		Help: "Max number of bytes to be retained in the tsdb blocks, configured 0 means disabled",
+	})
 	m.sizeRetentionCount = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "prometheus_tsdb_size_retentions_total",
 		Help: "The number of times that blocks were deleted because the maximum number of bytes was exceeded.",
@@ -244,6 +249,7 @@ func newDBMetrics(db *DB, r prometheus.Registerer) *dbMetrics {
 			m.startTime,
 			m.tombCleanTimer,
 			m.blocksBytes,
+			m.maxBytes,
 			m.sizeRetentionCount,
 		)
 	}
@@ -281,6 +287,12 @@ func Open(dir string, l log.Logger, r prometheus.Registerer, opts *Options) (db 
 		chunkPool:   chunkenc.NewPool(),
 	}
 	db.metrics = newDBMetrics(db, r)
+
+	maxBytes := opts.MaxBytes
+	if maxBytes < 0 {
+		maxBytes = 0
+	}
+	db.metrics.maxBytes.Set(float64(maxBytes))
 
 	if !opts.NoLockfile {
 		absdir, err := filepath.Abs(dir)

--- a/db_test.go
+++ b/db_test.go
@@ -1140,6 +1140,30 @@ func TestSizeRetention(t *testing.T) {
 
 }
 
+func TestSizeRetentionMetric(t *testing.T) {
+	cases := []struct {
+		maxBytes    int64
+		expMaxBytes int64
+	}{
+		{maxBytes: 1000, expMaxBytes: 1000},
+		{maxBytes: 0, expMaxBytes: 0},
+		{maxBytes: -1000, expMaxBytes: 0},
+	}
+
+	for _, c := range cases {
+		db, delete := openTestDB(t, &Options{
+			BlockRanges: []int64{100},
+			MaxBytes:    c.maxBytes,
+		})
+
+		actMaxBytes := int64(prom_testutil.ToFloat64(db.metrics.maxBytes))
+		testutil.Equals(t, actMaxBytes, c.expMaxBytes, "metric retention limit bytes mismatch")
+
+		testutil.Ok(t, db.Close())
+		delete()
+	}
+}
+
 func TestNotMatcherSelectsLabelsUnsetSeries(t *testing.T) {
 	db, delete := openTestDB(t, nil)
 	defer func() {


### PR DESCRIPTION
Signed-off-by: YaoZengzeng <yaozengzeng@zju.edu.cn>

fixes: prometheus/prometheus#5790
<!--
    Don't forget!
    
    - Most PRs would require a CHANGELOG entry.
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->