### PR TITLE
remove redundant condition judgement whether cut new chunk

### DIFF
--- a/chunks/chunks.go
+++ b/chunks/chunks.go
@@ -295,7 +295,7 @@ func (w *Writer) WriteChunks(chks ...Meta) error {
 	}
 	newsz := w.n + maxLen
 
-	if w.wbuf == nil || w.n > w.segmentSize || newsz > w.segmentSize && maxLen <= w.segmentSize {
+	if w.wbuf == nil || newsz > w.segmentSize && maxLen <= w.segmentSize {
 		if err := w.cut(); err != nil {
 			return err
 		}


### PR DESCRIPTION
Actually w.n will never > w.segmentSize when WriteChunks()

Signed-off-by: YaoZengzeng <yaozengzeng@zju.edu.cn>

<!--
    Don't forget!
    
    - Most PRs would require a CHANGELOG entry.
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->